### PR TITLE
feat(epic-3): Strategy Creation Two-Step Flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,8 @@ import { auth } from './api';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import RaceCreate from './pages/RaceCreate';
+import StrategyCreate from './pages/StrategyCreate';
+import StrategyCompare from './pages/StrategyCompare';
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -37,7 +39,8 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/races/new" element={<RaceCreate />} />
-          <Route path="/races/:id/strategy/new" element={<div className="placeholder">Strategy Creation (EPIC 3)</div>} />
+          <Route path="/races/:id/strategy/new" element={<StrategyCreate />} />
+          <Route path="/races/:id/strategy/compare" element={<StrategyCompare />} />
           <Route path="/races/:id" element={<div className="placeholder">Race Execution (EPIC 4)</div>} />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -30,3 +30,9 @@ export const races = {
   update: (id, data) => request(`/races/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   delete: (id) => request(`/races/${id}`, { method: 'DELETE' }),
 };
+
+export const strategies = {
+  list: (raceId) => request(`/strategies/${raceId}`),
+  calculate: (raceId, data) => request(`/strategies/${raceId}/calculate`, { method: 'POST', body: JSON.stringify(data) }),
+  activate: (raceId, strategyId) => request(`/strategies/${raceId}/activate/${strategyId}`, { method: 'POST' }),
+};

--- a/client/src/pages/StrategyCompare.jsx
+++ b/client/src/pages/StrategyCompare.jsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { strategies } from '../api';
+
+function formatTime(ms) {
+  if (!ms) return '—';
+  const m = Math.floor(ms / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+  const mil = ms % 1000;
+  return `${m}:${String(s).padStart(2, '0')}.${String(mil).padStart(3, '0')}`;
+}
+
+export default function StrategyCompare() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const variants = location.state?.variants || [];
+  const formValues = location.state?.formValues || {};
+  const [expanded, setExpanded] = useState(null);
+  const [activating, setActivating] = useState(false);
+
+  async function handleActivate(strategyId) {
+    setActivating(true);
+    try {
+      await strategies.activate(id, strategyId);
+      navigate(`/races/${id}`);
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      setActivating(false);
+    }
+  }
+
+  if (variants.length === 0) {
+    return (
+      <div className="strategy-compare" data-testid="strategy-compare-page">
+        <h2>Strategy — Step 2: Compare</h2>
+        <p>No variants available. <button className="btn-secondary" onClick={() => navigate(`/races/${id}/strategy/new`)}>Go back</button></p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="strategy-compare" data-testid="strategy-compare-page">
+      <h2>Strategy — Step 2: Compare & Choose</h2>
+
+      <table className="compare-table" data-testid="compare-table">
+        <thead>
+          <tr>
+            <th>Variant</th>
+            <th>Total Laps</th>
+            <th>Pit Stops</th>
+            <th>Avg Pace</th>
+            <th>Feasibility</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {variants.map((v, i) => (
+            <React.Fragment key={v.id || i}>
+              <tr data-testid={`variant-row-${i}`}>
+                <td><button className="link-btn" data-testid={`expand-variant-${i}`} onClick={() => setExpanded(expanded === i ? null : i)}>{v.name}</button></td>
+                <td>{v.estimatedTotalLaps}</td>
+                <td>{v.pitStops}</td>
+                <td>{formatTime(v.avgPace)}</td>
+                <td>{v.feasible ? <span className="badge active">Feasible</span> : <span className="badge warning" data-testid="feasibility-warning">Tyre shortage</span>}</td>
+                <td><button className="btn-primary btn-sm" data-testid={`activate-variant-${i}`} onClick={() => handleActivate(v.id)} disabled={activating}>Use this</button></td>
+              </tr>
+              {expanded === i && (
+                <tr className="detail-row" data-testid={`variant-detail-${i}`}>
+                  <td colSpan="6">
+                    <div className="stint-detail">
+                      {v.fuelSaveTargets && (
+                        <div className="fuel-save-targets" data-testid="fuel-save-targets">
+                          <h4>Fuel Save Targets</h4>
+                          {v.fuelSaveTargets.map(t => (
+                            <div key={t.driverId}>{t.driverName}: {t.targetFuelPerLap.toFixed(2)}%/lap fuel, max pace loss {t.maxPaceLoss}</div>
+                          ))}
+                        </div>
+                      )}
+                      {!v.feasible && <div className="warning-box" data-testid="tyre-warning">Warning: Tyre supply insufficient. {v.tyresUsed} tyres needed vs available.</div>}
+                      <table className="stint-table" data-testid="stint-table">
+                        <thead>
+                          <tr><th>#</th><th>Driver</th><th>Start Lap</th><th>End Lap</th><th>Fuel Load</th><th>Tyre Change</th><th>Est. Start</th><th>Pit Time</th></tr>
+                        </thead>
+                        <tbody>
+                          {v.stints.map(s => (
+                            <tr key={s.stintNumber}>
+                              <td>{s.stintNumber}</td>
+                              <td>{s.driverName}</td>
+                              <td>{s.plannedStartLap}</td>
+                              <td>{s.plannedEndLap}</td>
+                              <td>{s.fuelLoad}%</td>
+                              <td>{s.tyresChanged > 0 ? `Yes (${s.tyresChanged})` : 'No'}</td>
+                              <td>{s.estimatedStartTime ? new Date(s.estimatedStartTime).toLocaleTimeString() : '—'}</td>
+                              <td>{s.estimatedPitTime ? `${s.estimatedPitTime.toFixed(1)}s` : '—'}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="form-actions">
+        <button className="btn-secondary" data-testid="back-to-step1" onClick={() => navigate(`/races/${id}/strategy/new`, { state: { formValues } })}>Back to Step 1</button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/StrategyCreate.jsx
+++ b/client/src/pages/StrategyCreate.jsx
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { races, strategies } from '../api';
+
+export default function StrategyCreate() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [race, setRace] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const [name, setName] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [fuelPerLap, setFuelPerLap] = useState('');
+  const [energyPerLap, setEnergyPerLap] = useState('');
+  const [tyreDegFL, setTyreDegFL] = useState('');
+  const [tyreDegFR, setTyreDegFR] = useState('');
+  const [tyreDegRL, setTyreDegRL] = useState('');
+  const [tyreDegRR, setTyreDegRR] = useState('');
+  const [estimatedTotalLaps, setEstimatedTotalLaps] = useState('');
+  const [error, setError] = useState('');
+  const [calculating, setCalculating] = useState(false);
+
+  useEffect(() => {
+    races.get(id).then(r => {
+      setRace(r);
+      setName(`${r.name} Strategy`);
+      setFuelPerLap(String(r.fuel_per_lap));
+      setEnergyPerLap(String(r.energy_per_lap));
+      setTyreDegFL(String(r.tyre_deg_fl));
+      setTyreDegFR(String(r.tyre_deg_fr));
+      setTyreDegRL(String(r.tyre_deg_rl));
+      setTyreDegRR(String(r.tyre_deg_rr));
+      setEstimatedTotalLaps(String(r.estimated_total_laps));
+    }).catch(err => setError(err.message)).finally(() => setLoading(false));
+  }, [id]);
+
+  async function handleCalculate(e) {
+    e.preventDefault();
+    setError('');
+
+    const fuel = parseFloat(fuelPerLap);
+    const energy = parseFloat(energyPerLap);
+    const laps = parseInt(estimatedTotalLaps);
+
+    if (fuel < 0 || fuel > 200) { setError('Fuel per lap must be 0-200'); return; }
+    if (energy < 0 || energy > 100) { setError('Energy per lap must be 0-100'); return; }
+    if (!laps || laps <= 0) { setError('Estimated total laps must be > 0'); return; }
+
+    setCalculating(true);
+    try {
+      const variants = await strategies.calculate(id, {
+        name,
+        startTime: startTime || undefined,
+        fuelPerLap: fuel,
+        energyPerLap: energy,
+        tyreDegFL: parseFloat(tyreDegFL),
+        tyreDegFR: parseFloat(tyreDegFR),
+        tyreDegRL: parseFloat(tyreDegRL),
+        tyreDegRR: parseFloat(tyreDegRR),
+        estimatedTotalLaps: laps,
+      });
+      navigate(`/races/${id}/strategy/compare`, { state: { variants, formValues: { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps } } });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setCalculating(false);
+    }
+  }
+
+  if (loading) return <div className="loading">Loading race data...</div>;
+  if (!race) return <div className="error">Race not found</div>;
+
+  return (
+    <div className="strategy-create" data-testid="strategy-create-page">
+      <h2>Strategy — Step 1: Configure</h2>
+      <p className="subtitle">Race: {race.name}</p>
+      {error && <div className="error" data-testid="strategy-error">{error}</div>}
+      <form onSubmit={handleCalculate}>
+        <div className="form-row">
+          <div className="form-group">
+            <label>Strategy Name</label>
+            <input type="text" data-testid="strategy-name-input" value={name} onChange={e => setName(e.target.value)} required />
+          </div>
+          <div className="form-group">
+            <label>Race Start Time</label>
+            <input type="datetime-local" data-testid="start-time-input" value={startTime} onChange={e => setStartTime(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="form-group">
+            <label>Fuel/Lap (%)</label>
+            <input type="number" data-testid="strategy-fuel-input" value={fuelPerLap} onChange={e => setFuelPerLap(e.target.value)} min="0" max="200" step="0.01" />
+          </div>
+          <div className="form-group">
+            <label>Energy/Lap (%)</label>
+            <input type="number" data-testid="strategy-energy-input" value={energyPerLap} onChange={e => setEnergyPerLap(e.target.value)} min="0" max="100" step="0.01" />
+          </div>
+          <div className="form-group">
+            <label>Est. Total Laps</label>
+            <input type="number" data-testid="strategy-laps-input" value={estimatedTotalLaps} onChange={e => setEstimatedTotalLaps(e.target.value)} min="1" />
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="form-group"><label>Tyre Deg FL (%/lap)</label><input type="number" data-testid="strategy-tyre-fl-input" value={tyreDegFL} onChange={e => setTyreDegFL(e.target.value)} min="0" max="100" step="0.01" /></div>
+          <div className="form-group"><label>Tyre Deg FR (%/lap)</label><input type="number" data-testid="strategy-tyre-fr-input" value={tyreDegFR} onChange={e => setTyreDegFR(e.target.value)} min="0" max="100" step="0.01" /></div>
+          <div className="form-group"><label>Tyre Deg RL (%/lap)</label><input type="number" data-testid="strategy-tyre-rl-input" value={tyreDegRL} onChange={e => setTyreDegRL(e.target.value)} min="0" max="100" step="0.01" /></div>
+          <div className="form-group"><label>Tyre Deg RR (%/lap)</label><input type="number" data-testid="strategy-tyre-rr-input" value={tyreDegRR} onChange={e => setTyreDegRR(e.target.value)} min="0" max="100" step="0.01" /></div>
+        </div>
+
+        <div className="form-actions">
+          <button type="button" className="btn-secondary" onClick={() => navigate(`/races/${id}`)}>Cancel</button>
+          <button type="submit" className="btn-primary" data-testid="calculate-btn" disabled={calculating}>
+            {calculating ? 'Calculating...' : 'Calculate Strategy'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -76,5 +76,23 @@ input:focus, select:focus { outline: none; border-color: #6366f1; }
 .race-create { background: #1e293b; padding: 2rem; border-radius: 12px; }
 .race-create h2 { margin-bottom: 1.5rem; }
 
+/* Strategy */
+.strategy-create, .strategy-compare { background: #1e293b; padding: 2rem; border-radius: 12px; }
+.strategy-create h2, .strategy-compare h2 { margin-bottom: 0.5rem; }
+.subtitle { color: #94a3b8; margin-bottom: 1.5rem; font-size: 0.9rem; }
+.compare-table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
+.compare-table th, .compare-table td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #334155; }
+.compare-table th { color: #94a3b8; font-size: 0.8rem; text-transform: uppercase; }
+.link-btn { background: none; color: #818cf8; text-decoration: underline; padding: 0; border: none; cursor: pointer; }
+.detail-row td { padding: 1rem; background: #0f172a; }
+.stint-detail { overflow-x: auto; }
+.stint-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.stint-table th, .stint-table td { padding: 0.5rem; border-bottom: 1px solid #1e293b; }
+.stint-table th { color: #94a3b8; }
+.fuel-save-targets { margin-bottom: 1rem; font-size: 0.85rem; color: #fcd34d; }
+.fuel-save-targets h4 { margin-bottom: 0.25rem; }
+.warning-box { background: #78350f; color: #fcd34d; padding: 0.5rem 1rem; border-radius: 6px; margin-bottom: 1rem; }
+.badge.warning { background: #78350f; color: #fcd34d; }
+
 /* Placeholder */
 .placeholder { text-align: center; padding: 3rem; color: #64748b; font-style: italic; }

--- a/server/engine/pitTime.js
+++ b/server/engine/pitTime.js
@@ -1,0 +1,45 @@
+const REFUEL_TABLE = {};
+const exactValues = {
+  1:2.2,2:2.4,3:2.6,4:2.8,5:3.1,6:3.3,7:3.5,8:3.7,9:3.9,10:4.1,
+  11:4.4,12:4.8,13:5.2,14:5.6,15:6.0,16:6.4,17:6.8,18:7.2,19:7.6,20:8.0,
+  21:8.4,22:8.8,23:9.2,24:9.6,25:10.0,26:10.4,27:10.8,28:11.2,29:11.6,30:12.0,
+  31:12.4,32:12.8,33:13.2,34:13.6,35:14.0,36:14.4,37:14.8,38:15.2,39:15.6,40:16.0,
+  41:16.4,42:16.8,43:17.2,44:17.6,45:18.0,46:18.4,47:18.8,48:19.2,49:19.6,50:20.0,
+  51:20.4,52:20.8,53:21.2,54:21.6,55:22.0,56:22.4,57:22.8,58:23.2,59:23.6,60:24.0,
+  61:24.4,62:24.8,63:25.2,64:25.6,65:26.0,66:26.4,67:26.8,68:27.2,69:27.6,70:28.0,
+  71:28.4,72:28.8,73:29.2,74:29.6,75:30.0,76:30.4,77:30.8,78:31.2,79:31.6,80:32.0,
+  81:32.4,82:32.8,83:33.2,84:33.6,85:34.0,86:34.4,87:34.8,88:35.2,89:35.6,90:36.0,
+  91:36.4,92:36.8,93:37.2,94:37.6,95:38.0,96:38.4,97:38.8,98:39.2,99:39.6,100:40.0
+};
+Object.entries(exactValues).forEach(([k, v]) => { REFUEL_TABLE[Number(k)] = v; });
+
+function getRefuelTime(fuelPct) {
+  if (fuelPct <= 0) return 0;
+  if (fuelPct >= 100) return REFUEL_TABLE[100];
+  const lower = Math.floor(fuelPct);
+  const upper = Math.ceil(fuelPct);
+  if (lower === upper) return REFUEL_TABLE[lower] || 0;
+  const lowerTime = REFUEL_TABLE[lower] || 0;
+  const upperTime = REFUEL_TABLE[upper] || 0;
+  return lowerTime + (upperTime - lowerTime) * (fuelPct - lower);
+}
+
+const DAMAGE_TIME = {
+  none: 0,
+  bodywork: 32.5,
+  bodywork_rear_wing: 60,
+  yellow_suspension: 32.5,
+  orange_suspension: 110,
+  red_suspension: 180,
+};
+
+const TYRE_CHANGE_TIME = { 0: 0, 1: 5, 2: 5, 3: 12, 4: 12 };
+
+function calculatePitTime({ fuelAdded = 0, tyresChanged = 4, damageType = 'none' }) {
+  const refuel = getRefuelTime(fuelAdded);
+  const damage = DAMAGE_TIME[damageType] || 0;
+  const tyres = TYRE_CHANGE_TIME[tyresChanged] || 0;
+  return refuel + damage + tyres;
+}
+
+module.exports = { calculatePitTime, getRefuelTime, DAMAGE_TIME, TYRE_CHANGE_TIME };

--- a/server/engine/strategy.js
+++ b/server/engine/strategy.js
@@ -1,0 +1,183 @@
+const { calculatePitTime } = require('./pitTime');
+
+const ENERGY_RESERVE = 0.1;
+const MAX_STINTS = 200;
+const MAX_LAPS = 5000;
+
+function calculateStintLength({ fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR }) {
+  const limits = [];
+  if (fuelPerLap > 0) limits.push(Math.floor(100 / fuelPerLap));
+  if (energyPerLap > 0) limits.push(Math.floor((100 - ENERGY_RESERVE) / energyPerLap));
+  const maxTyreDeg = Math.max(tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR);
+  if (maxTyreDeg > 0) limits.push(Math.floor(100 / maxTyreDeg));
+  if (limits.length === 0) return 999;
+  return Math.min(...limits);
+}
+
+function generateStintPlan({ drivers, estimatedTotalLaps, stintLength, startLap = 1, availableTyres, avgPitFuel = 100, startTime = null, avgLapTimeMs = null }) {
+  const stints = [];
+  let currentLap = startLap;
+  let driverIndex = 0;
+  let tyresUsed = 0;
+  let stintNumber = 1;
+
+  const totalLaps = Math.min(estimatedTotalLaps, MAX_LAPS);
+  const effectiveStintLength = Math.max(1, stintLength);
+
+  while (currentLap <= totalLaps && stintNumber <= MAX_STINTS) {
+    const driver = drivers[driverIndex % drivers.length];
+    const remainingLaps = totalLaps - currentLap + 1;
+    const lapsThisStint = Math.min(effectiveStintLength, remainingLaps);
+    const endLap = currentLap + lapsThisStint - 1;
+
+    const isLastStint = endLap >= totalLaps;
+    const tyresChanged = isLastStint ? 0 : 4;
+    if (tyresChanged > 0) tyresUsed += tyresChanged;
+
+    const pitTime = isLastStint ? 0 : calculatePitTime({ fuelAdded: avgPitFuel, tyresChanged, damageType: 'none' });
+
+    let estimatedStartTime = null;
+    if (startTime && avgLapTimeMs) {
+      const elapsedLaps = currentLap - startLap;
+      const prevPitStops = stints.length;
+      const avgPitTime = calculatePitTime({ fuelAdded: avgPitFuel, tyresChanged: 4, damageType: 'none' });
+      const totalElapsedMs = (elapsedLaps * avgLapTimeMs) + (prevPitStops * avgPitTime * 1000);
+      estimatedStartTime = new Date(new Date(startTime).getTime() + totalElapsedMs).toISOString();
+    }
+
+    stints.push({
+      stintNumber,
+      driverId: driver.id,
+      driverName: driver.name,
+      plannedStartLap: currentLap,
+      plannedEndLap: endLap,
+      fuelLoad: avgPitFuel,
+      tyresChanged,
+      estimatedStartTime,
+      estimatedPitTime: pitTime,
+    });
+
+    currentLap = endLap + 1;
+    driverIndex++;
+    stintNumber++;
+  }
+
+  return { stints, tyresUsed, feasible: tyresUsed <= availableTyres };
+}
+
+function generateVariants({ race, drivers, startTime, overrides = {} }) {
+  const params = {
+    fuelPerLap: overrides.fuelPerLap ?? race.fuel_per_lap,
+    energyPerLap: overrides.energyPerLap ?? race.energy_per_lap,
+    tyreDegFL: overrides.tyreDegFL ?? race.tyre_deg_fl,
+    tyreDegFR: overrides.tyreDegFR ?? race.tyre_deg_fr,
+    tyreDegRL: overrides.tyreDegRL ?? race.tyre_deg_rl,
+    tyreDegRR: overrides.tyreDegRR ?? race.tyre_deg_rr,
+  };
+
+  const estimatedTotalLaps = overrides.estimatedTotalLaps ?? race.estimated_total_laps;
+  const availableTyres = race.available_tyres;
+
+  const avgLapTimeMs = drivers.length > 0
+    ? drivers.reduce((sum, d) => sum + d.avg_lap_time_ms, 0) / drivers.length
+    : null;
+
+  const normalStintLength = calculateStintLength(params);
+  const fuelSaveParams = { ...params, fuelPerLap: params.fuelPerLap * 0.85 };
+  const fuelSaveStintLength = calculateStintLength(fuelSaveParams);
+  const mixedStintLength = Math.floor((normalStintLength + fuelSaveStintLength) / 2);
+
+  const commonOpts = { drivers, estimatedTotalLaps, availableTyres, startTime, avgLapTimeMs };
+
+  const normalPlan = generateStintPlan({ ...commonOpts, stintLength: normalStintLength });
+  const fuelSavePlan = generateStintPlan({ ...commonOpts, stintLength: fuelSaveStintLength });
+  const mixedPlan = generateStintPlan({ ...commonOpts, stintLength: mixedStintLength });
+
+  const variants = [
+    {
+      name: 'Normal Pace',
+      stintLength: normalStintLength,
+      ...normalPlan,
+      params,
+      estimatedTotalLaps,
+      pitStops: normalPlan.stints.length - 1,
+      avgPace: avgLapTimeMs,
+    },
+    {
+      name: 'Fuel Save',
+      stintLength: fuelSaveStintLength,
+      ...fuelSavePlan,
+      params: fuelSaveParams,
+      estimatedTotalLaps,
+      pitStops: fuelSavePlan.stints.length - 1,
+      avgPace: avgLapTimeMs ? Math.round(avgLapTimeMs * 1.02) : null,
+      fuelSaveTargets: drivers.map(d => ({
+        driverId: d.id,
+        driverName: d.name,
+        targetFuelPerLap: fuelSaveParams.fuelPerLap,
+        targetEnergyPerLap: (overrides.energyPerLap ?? race.energy_per_lap) * 0.9,
+        maxPaceLoss: '2%',
+      })),
+    },
+    {
+      name: 'Mixed',
+      stintLength: mixedStintLength,
+      ...mixedPlan,
+      params: { ...params, fuelPerLap: (params.fuelPerLap + fuelSaveParams.fuelPerLap) / 2 },
+      estimatedTotalLaps,
+      pitStops: mixedPlan.stints.length - 1,
+      avgPace: avgLapTimeMs ? Math.round(avgLapTimeMs * 1.01) : null,
+    },
+  ];
+
+  return variants;
+}
+
+function recalculateFromLap({ race, drivers, strategy, confirmedStints, currentLap, startTime }) {
+  const params = {
+    fuelPerLap: strategy.fuel_per_lap || race.fuel_per_lap,
+    energyPerLap: strategy.energy_per_lap || race.energy_per_lap,
+    tyreDegFL: strategy.tyre_deg_fl || race.tyre_deg_fl,
+    tyreDegFR: strategy.tyre_deg_fr || race.tyre_deg_fr,
+    tyreDegRL: strategy.tyre_deg_rl || race.tyre_deg_rl,
+    tyreDegRR: strategy.tyre_deg_rr || race.tyre_deg_rr,
+  };
+
+  const estimatedTotalLaps = race.estimated_total_laps;
+  const stintLength = calculateStintLength(params);
+  const availableTyres = race.available_tyres;
+  const tyresUsedConfirmed = confirmedStints.reduce((sum, s) => sum + (s.tyres_changed || 0), 0);
+  const remainingTyres = availableTyres - tyresUsedConfirmed;
+
+  const lastConfirmedDriverIndex = confirmedStints.length > 0
+    ? drivers.findIndex(d => d.id === confirmedStints[confirmedStints.length - 1].driver_id)
+    : -1;
+
+  const rotatedDrivers = [];
+  for (let i = 0; i < drivers.length; i++) {
+    rotatedDrivers.push(drivers[(lastConfirmedDriverIndex + 1 + i) % drivers.length]);
+  }
+
+  const avgLapTimeMs = drivers.length > 0
+    ? drivers.reduce((sum, d) => sum + d.avg_lap_time_ms, 0) / drivers.length
+    : null;
+
+  const plan = generateStintPlan({
+    drivers: rotatedDrivers,
+    estimatedTotalLaps,
+    stintLength,
+    startLap: currentLap,
+    availableTyres: remainingTyres,
+    startTime,
+    avgLapTimeMs,
+  });
+
+  plan.stints = plan.stints.map((s, i) => ({
+    ...s,
+    stintNumber: confirmedStints.length + i + 1,
+  }));
+
+  return plan;
+}
+
+module.exports = { generateVariants, recalculateFromLap, calculateStintLength };

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ require('./db/migrate');
 
 const authRoutes = require('./routes/auth');
 const racesRoutes = require('./routes/races');
+const strategiesRoutes = require('./routes/strategies');
 const { requireAuth } = require('./middleware/auth');
 
 const app = express();
@@ -23,6 +24,7 @@ app.use(session({
 
 app.use('/api/auth', authRoutes);
 app.use('/api/races', racesRoutes);
+app.use('/api/strategies', strategiesRoutes);
 
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });

--- a/server/routes/strategies.js
+++ b/server/routes/strategies.js
@@ -1,0 +1,105 @@
+const { Router } = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+const { generateVariants } = require('../engine/strategy');
+
+const router = Router();
+router.use(requireAuth);
+
+router.post('/:raceId/calculate', (req, res) => {
+  const race = db.prepare('SELECT * FROM races WHERE id = ? AND user_id = ?').get(req.params.raceId, req.session.userId);
+  if (!race) return res.status(404).json({ error: 'Race not found' });
+
+  const drivers = db.prepare('SELECT * FROM drivers WHERE race_id = ? ORDER BY rotation_order').all(race.id);
+  if (drivers.length === 0) {
+    return res.status(400).json({ error: 'Race must have at least one driver' });
+  }
+
+  const { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps } = req.body;
+
+  if (fuelPerLap !== undefined && (fuelPerLap < 0 || fuelPerLap > 200)) {
+    return res.status(400).json({ error: 'Fuel per lap must be 0-200' });
+  }
+  if (energyPerLap !== undefined && (energyPerLap < 0 || energyPerLap > 100)) {
+    return res.status(400).json({ error: 'Energy per lap must be 0-100' });
+  }
+  const tyreDegFields = [tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR];
+  for (const val of tyreDegFields) {
+    if (val !== undefined && (val < 0 || val > 100)) {
+      return res.status(400).json({ error: 'Tyre wear must be 0-100' });
+    }
+  }
+  if (estimatedTotalLaps !== undefined && estimatedTotalLaps <= 0) {
+    return res.status(400).json({ error: 'Estimated total laps must be > 0' });
+  }
+
+  const overrides = {};
+  if (fuelPerLap !== undefined) overrides.fuelPerLap = fuelPerLap;
+  if (energyPerLap !== undefined) overrides.energyPerLap = energyPerLap;
+  if (tyreDegFL !== undefined) overrides.tyreDegFL = tyreDegFL;
+  if (tyreDegFR !== undefined) overrides.tyreDegFR = tyreDegFR;
+  if (tyreDegRL !== undefined) overrides.tyreDegRL = tyreDegRL;
+  if (tyreDegRR !== undefined) overrides.tyreDegRR = tyreDegRR;
+  if (estimatedTotalLaps !== undefined) overrides.estimatedTotalLaps = estimatedTotalLaps;
+
+  const variants = generateVariants({ race, drivers, startTime, overrides });
+
+  const strategyName = name || `Strategy ${new Date().toISOString().slice(0, 16)}`;
+
+  const insertStrategy = db.prepare(`
+    INSERT INTO strategies (race_id, name, variant_name, start_time, fuel_per_lap, energy_per_lap, tyre_deg_fl, tyre_deg_fr, tyre_deg_rl, tyre_deg_rr, estimated_total_laps, data)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const savedVariants = variants.map(v => {
+    const result = insertStrategy.run(
+      race.id, strategyName, v.name, startTime || null,
+      overrides.fuelPerLap ?? race.fuel_per_lap,
+      overrides.energyPerLap ?? race.energy_per_lap,
+      overrides.tyreDegFL ?? race.tyre_deg_fl,
+      overrides.tyreDegFR ?? race.tyre_deg_fr,
+      overrides.tyreDegRL ?? race.tyre_deg_rl,
+      overrides.tyreDegRR ?? race.tyre_deg_rr,
+      overrides.estimatedTotalLaps ?? race.estimated_total_laps,
+      JSON.stringify(v)
+    );
+    return { id: result.lastInsertRowid, ...v };
+  });
+
+  res.status(201).json(savedVariants);
+});
+
+router.post('/:raceId/activate/:strategyId', (req, res) => {
+  const race = db.prepare('SELECT * FROM races WHERE id = ? AND user_id = ?').get(req.params.raceId, req.session.userId);
+  if (!race) return res.status(404).json({ error: 'Race not found' });
+
+  const strategy = db.prepare('SELECT * FROM strategies WHERE id = ? AND race_id = ?').get(req.params.strategyId, race.id);
+  if (!strategy) return res.status(404).json({ error: 'Strategy not found' });
+
+  db.prepare('UPDATE strategies SET is_active = 0 WHERE race_id = ?').run(race.id);
+  db.prepare('UPDATE strategies SET is_active = 1 WHERE id = ?').run(strategy.id);
+
+  db.prepare('DELETE FROM stints WHERE strategy_id = ?').run(strategy.id);
+  const data = JSON.parse(strategy.data);
+  const insertStint = db.prepare(`
+    INSERT INTO stints (race_id, strategy_id, driver_id, stint_number, planned_start_lap, planned_end_lap, fuel_load, tyres_changed, estimated_start_time)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  if (data.stints) {
+    data.stints.forEach(s => {
+      insertStint.run(race.id, strategy.id, s.driverId, s.stintNumber, s.plannedStartLap, s.plannedEndLap, s.fuelLoad, s.tyresChanged, s.estimatedStartTime);
+    });
+  }
+
+  res.json({ ...strategy, is_active: 1 });
+});
+
+router.get('/:raceId', (req, res) => {
+  const race = db.prepare('SELECT * FROM races WHERE id = ? AND user_id = ?').get(req.params.raceId, req.session.userId);
+  if (!race) return res.status(404).json({ error: 'Race not found' });
+  const strategies = db.prepare('SELECT * FROM strategies WHERE race_id = ?').all(race.id);
+  res.json(strategies.map(s => ({ ...s, data: JSON.parse(s.data) })));
+});
+
+module.exports = router;

--- a/server/tests/strategy.test.js
+++ b/server/tests/strategy.test.js
@@ -1,0 +1,81 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { calculatePitTime, getRefuelTime } = require('../engine/pitTime');
+const { generateVariants, calculateStintLength } = require('../engine/strategy');
+
+describe('Pit Time Calculator', () => {
+  test('refuel time matches appendix A1', () => {
+    assert.strictEqual(getRefuelTime(1), 2.2);
+    assert.strictEqual(getRefuelTime(50), 20.0);
+    assert.strictEqual(getRefuelTime(100), 40.0);
+    assert.strictEqual(getRefuelTime(80), 32.0);
+  });
+
+  test('refuel time interpolates between values', () => {
+    const time = getRefuelTime(50.5);
+    assert(time > 20.0 && time < 20.4);
+  });
+
+  test('tyre change time matches appendix A3', () => {
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 0, damageType: 'none' }), 0);
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 1, damageType: 'none' }), 5);
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 4, damageType: 'none' }), 12);
+  });
+
+  test('damage time matches appendix A2', () => {
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 0, damageType: 'bodywork' }), 32.5);
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 0, damageType: 'bodywork_rear_wing' }), 60);
+    assert.strictEqual(calculatePitTime({ fuelAdded: 0, tyresChanged: 0, damageType: 'red_suspension' }), 180);
+  });
+
+  test('total pit time is sum of components', () => {
+    const time = calculatePitTime({ fuelAdded: 80, tyresChanged: 4, damageType: 'bodywork' });
+    assert.strictEqual(time, 32.0 + 12 + 32.5);
+  });
+});
+
+describe('Strategy Engine', () => {
+  test('stint length respects fuel limit', () => {
+    const length = calculateStintLength({ fuelPerLap: 5, energyPerLap: 0, tyreDegFL: 0, tyreDegFR: 0, tyreDegRL: 0, tyreDegRR: 0 });
+    assert.strictEqual(length, 20);
+  });
+
+  test('stint length respects energy limit with reserve', () => {
+    const length = calculateStintLength({ fuelPerLap: 0, energyPerLap: 5, tyreDegFL: 0, tyreDegFR: 0, tyreDegRL: 0, tyreDegRR: 0 });
+    assert.strictEqual(length, 19); // (100 - 0.1) / 5 = 19.98 -> floor = 19
+  });
+
+  test('stint length respects tyre limit', () => {
+    const length = calculateStintLength({ fuelPerLap: 0, energyPerLap: 0, tyreDegFL: 2, tyreDegFR: 3, tyreDegRL: 1, tyreDegRR: 1 });
+    assert.strictEqual(length, 33); // 100 / 3 = 33.33 -> floor = 33
+  });
+
+  test('stint length is minimum of all limits', () => {
+    const length = calculateStintLength({ fuelPerLap: 5, energyPerLap: 10, tyreDegFL: 2, tyreDegFR: 2, tyreDegRL: 2, tyreDegRR: 2 });
+    assert.strictEqual(length, 9); // energy: (99.9/10)=9
+  });
+
+  test('generates 3 variants', () => {
+    const race = { fuel_per_lap: 3.5, energy_per_lap: 2, tyre_deg_fl: 1, tyre_deg_fr: 1, tyre_deg_rl: 1, tyre_deg_rr: 1, estimated_total_laps: 100, available_tyres: 32 };
+    const drivers = [{ id: 1, name: 'Alice', avg_lap_time_ms: 90000 }, { id: 2, name: 'Bob', avg_lap_time_ms: 91000 }];
+    const variants = generateVariants({ race, drivers, startTime: null, overrides: {} });
+    assert.strictEqual(variants.length, 3);
+    assert.strictEqual(variants[0].name, 'Normal Pace');
+    assert.strictEqual(variants[1].name, 'Fuel Save');
+    assert.strictEqual(variants[2].name, 'Mixed');
+  });
+
+  test('fuel save variant has longer stints', () => {
+    const race = { fuel_per_lap: 3.5, energy_per_lap: 2, tyre_deg_fl: 1, tyre_deg_fr: 1, tyre_deg_rl: 1, tyre_deg_rr: 1, estimated_total_laps: 100, available_tyres: 32 };
+    const drivers = [{ id: 1, name: 'Alice', avg_lap_time_ms: 90000 }];
+    const variants = generateVariants({ race, drivers, startTime: null, overrides: {} });
+    assert(variants[1].stintLength >= variants[0].stintLength);
+  });
+
+  test('feasibility flag when tyres insufficient', () => {
+    const race = { fuel_per_lap: 10, energy_per_lap: 0, tyre_deg_fl: 0, tyre_deg_fr: 0, tyre_deg_rl: 0, tyre_deg_rr: 0, estimated_total_laps: 200, available_tyres: 4 };
+    const drivers = [{ id: 1, name: 'Alice', avg_lap_time_ms: 90000 }];
+    const variants = generateVariants({ race, drivers, startTime: null, overrides: {} });
+    assert.strictEqual(variants[0].feasible, false);
+  });
+});


### PR DESCRIPTION
## Description
Build the two-step strategy creation flow: configure parameters and calculate variants, then compare and activate one.

## User Stories

### Step 1 - Configure and Calculate
- US-30: Input form with strategy name, start time, fuel/lap, energy/lap, tyre wear, estimated total laps (pre-filled from race)
- US-31: Validation: fuel 0-200, energy 0-100, tyre wear 0-100, total laps > 0
- US-32: "Calculate" runs engine and advances to Step 2 with loading indicator
- US-33: At least 3 variants generated (Normal Pace, Fuel Save, Mixed)

### Step 2 - Compare and Choose
- US-34: Comparison table: variant name, total laps, pit stops, avg pace, feasibility warnings
- US-35: Expand variant to see full stint plan (stint number, driver, laps, fuel, tyres, start time, pit time)
- US-36: Fuel-save variant shows per-driver targets
- US-37: Feasibility warning when tyres insufficient
- US-38: "Use this strategy" activates variant and navigates to execution
- US-39: "Back" returns to Step 1 with values intact

## Acceptance Criteria
- [ ] POST `/api/strategies/:raceId/calculate` returns 3+ variants
- [ ] Each variant contains complete stint plan
- [ ] Strategy engine respects: fuel limit, energy limit (with 0.1% reserve), tyre degradation
- [ ] Stint length = min(fuel limit, energy limit, tyre limit)
- [ ] Fuel Save variant uses 85% of normal fuel/lap
- [ ] Pit time computed from Appendix A (never manual)
- [ ] POST `/api/strategies/:raceId/activate/:id` marks one variant active, creates stint records
- [ ] Step 2 shows expandable stint details
- [ ] Feasibility warning when tyresUsed > availableTyres
- [ ] Back button preserves form state

## Technical Notes
- Strategy engine lives in `server/engine/strategy.js`
- Pit time calculator in `server/engine/pitTime.js`
- Pit time = Refuel time [A1] + Damage repair [A2] + Tyre change [A3]
- See Appendix A in req.md for lookup tables

## Dependencies
- EPIC 0 (Project Setup)
- EPIC 2 (Race Creation - provides race + driver data)
