### PR TITLE
fix: change fuel per lap unit from percentage to liters

### DIFF
--- a/client/src/pages/RaceCreate.jsx
+++ b/client/src/pages/RaceCreate.jsx
@@ -139,7 +139,7 @@ export default function RaceCreate() {
 
         <div className="form-row">
           <div className="form-group">
-            <label>Fuel/Lap (%)</label>
+            <label>Fuel/Lap (L)</label>
             <input type="number" data-testid="fuel-per-lap-input" value={fuelPerLap} onChange={e => setFuelPerLap(e.target.value)} min="0" max="200" step="0.01" />
           </div>
           <div className="form-group">

--- a/client/src/pages/StrategyCompare.jsx
+++ b/client/src/pages/StrategyCompare.jsx
@@ -74,7 +74,7 @@ export default function StrategyCompare() {
                         <div className="fuel-save-targets" data-testid="fuel-save-targets">
                           <h4>Fuel Save Targets</h4>
                           {v.fuelSaveTargets.map(t => (
-                            <div key={t.driverId}>{t.driverName}: {t.targetFuelPerLap.toFixed(2)}%/lap fuel, max pace loss {t.maxPaceLoss}</div>
+                            <div key={t.driverId}>{t.driverName}: {t.targetFuelPerLap.toFixed(2)} L/lap fuel, max pace loss {t.maxPaceLoss}</div>
                           ))}
                         </div>
                       )}

--- a/client/src/pages/StrategyCreate.jsx
+++ b/client/src/pages/StrategyCreate.jsx
@@ -42,7 +42,7 @@ export default function StrategyCreate() {
     const energy = parseFloat(energyPerLap);
     const laps = parseInt(estimatedTotalLaps);
 
-    if (fuel < 0 || fuel > 200) { setError('Fuel per lap must be 0-200'); return; }
+    if (fuel < 0 || fuel > 200) { setError('Fuel per lap must be 0-200 L'); return; }
     if (energy < 0 || energy > 100) { setError('Energy per lap must be 0-100'); return; }
     if (!laps || laps <= 0) { setError('Estimated total laps must be > 0'); return; }
 
@@ -89,7 +89,7 @@ export default function StrategyCreate() {
 
         <div className="form-row">
           <div className="form-group">
-            <label>Fuel/Lap (%)</label>
+            <label>Fuel/Lap (L)</label>
             <input type="number" data-testid="strategy-fuel-input" value={fuelPerLap} onChange={e => setFuelPerLap(e.target.value)} min="0" max="200" step="0.01" />
           </div>
           <div className="form-group">

--- a/server/routes/strategies.js
+++ b/server/routes/strategies.js
@@ -18,7 +18,7 @@ router.post('/:raceId/calculate', (req, res) => {
   const { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps } = req.body;
 
   if (fuelPerLap !== undefined && (fuelPerLap < 0 || fuelPerLap > 200)) {
-    return res.status(400).json({ error: 'Fuel per lap must be 0-200' });
+    return res.status(400).json({ error: 'Fuel per lap must be 0-200 L' });
   }
   if (energyPerLap !== undefined && (energyPerLap < 0 || energyPerLap > 100)) {
     return res.status(400).json({ error: 'Energy per lap must be 0-100' });


### PR DESCRIPTION
## Summary
- Fix fuel per lap unit label from "%" to "L" (liters) per requirement US-31
- Updates RaceCreate, StrategyCreate, StrategyCompare UI labels
- Updates server-side validation error message

## Test plan
- [x] Verify labels show "Fuel/Lap (L)" on race creation page
- [x] Verify labels show "Fuel/Lap (L)" on strategy creation page
- [x] Verify fuel save targets display "L/lap" on strategy comparison page
- [x] Verify validation message says "0-200 L"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
