### PR TITLE
feat(epic-6): tyre multiplicity, derived laps, pit-time column, pace format fix

### DIFF
--- a/client/src/pages/StrategyCompare.jsx
+++ b/client/src/pages/StrategyCompare.jsx
@@ -2,12 +2,21 @@ import React, { useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { strategies } from '../api';
 
-function formatTime(ms) {
+function formatLapTime(ms) {
   if (!ms) return '—';
-  const m = Math.floor(ms / 60000);
-  const s = Math.floor((ms % 60000) / 1000);
-  const mil = ms % 1000;
+  const totalMs = Math.round(ms);
+  const m = Math.floor(totalMs / 60000);
+  const s = Math.floor((totalMs % 60000) / 1000);
+  const mil = totalMs % 1000;
   return `${m}:${String(s).padStart(2, '0')}.${String(mil).padStart(3, '0')}`;
+}
+
+function formatPitTime(sec) {
+  if (!sec) return '—';
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
 }
 
 export default function StrategyCompare() {
@@ -51,59 +60,69 @@ export default function StrategyCompare() {
             <th>Total Laps</th>
             <th>Pit Stops</th>
             <th>Avg Pace</th>
+            <th>Time in pits (est.)</th>
             <th>Feasibility</th>
             <th>Action</th>
           </tr>
         </thead>
         <tbody>
-          {variants.map((v, i) => (
-            <React.Fragment key={v.id || i}>
-              <tr data-testid={`variant-row-${i}`}>
-                <td><button className="link-btn" data-testid={`expand-variant-${i}`} onClick={() => setExpanded(expanded === i ? null : i)}>{v.name}</button></td>
-                <td>{v.estimatedTotalLaps}</td>
-                <td>{v.pitStops}</td>
-                <td>{formatTime(v.avgPace)}</td>
-                <td>{v.feasible ? <span className="badge active">Feasible</span> : <span className="badge warning" data-testid="feasibility-warning">Tyre shortage</span>}</td>
-                <td><button className="btn-primary btn-sm" data-testid={`activate-variant-${i}`} onClick={() => handleActivate(v.id)} disabled={activating}>Use this</button></td>
-              </tr>
-              {expanded === i && (
-                <tr className="detail-row" data-testid={`variant-detail-${i}`}>
-                  <td colSpan="6">
-                    <div className="stint-detail">
-                      {v.fuelSaveTargets && (
-                        <div className="fuel-save-targets" data-testid="fuel-save-targets">
-                          <h4>Fuel Save Targets</h4>
-                          {v.fuelSaveTargets.map(t => (
-                            <div key={t.driverId}>{t.driverName}: {t.targetFuelPerLap.toFixed(2)} L/lap fuel, max pace loss {t.maxPaceLoss}</div>
-                          ))}
-                        </div>
-                      )}
-                      {!v.feasible && <div className="warning-box" data-testid="tyre-warning">Warning: Tyre supply insufficient. {v.tyresUsed} tyres needed vs available.</div>}
-                      <table className="stint-table" data-testid="stint-table">
-                        <thead>
-                          <tr><th>#</th><th>Driver</th><th>Start Lap</th><th>End Lap</th><th>Fuel Load</th><th>Tyre Change</th><th>Est. Start</th><th>Pit Time</th></tr>
-                        </thead>
-                        <tbody>
-                          {v.stints.map(s => (
-                            <tr key={s.stintNumber}>
-                              <td>{s.stintNumber}</td>
-                              <td>{s.driverName}</td>
-                              <td>{s.plannedStartLap}</td>
-                              <td>{s.plannedEndLap}</td>
-                              <td>{s.fuelLoad}%</td>
-                              <td>{s.tyresChanged > 0 ? `Yes (${s.tyresChanged})` : 'No'}</td>
-                              <td>{s.estimatedStartTime ? new Date(s.estimatedStartTime).toLocaleTimeString() : '—'}</td>
-                              <td>{s.estimatedPitTime ? `${s.estimatedPitTime.toFixed(1)}s` : '—'}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  </td>
+          {variants.map((v, i) => {
+            const needed = v.requiredTyreSets != null ? v.requiredTyreSets * 4 : v.tyresUsed;
+            const available = v.availableTyres;
+            const shortfallText = needed != null && available != null
+              ? `Needs ${needed} tyres, ${available} available`
+              : 'Tyre shortage';
+
+            return (
+              <React.Fragment key={v.id || i}>
+                <tr data-testid={`variant-row-${i}`}>
+                  <td><button className="link-btn" data-testid={`expand-variant-${i}`} onClick={() => setExpanded(expanded === i ? null : i)}>{v.name}</button></td>
+                  <td>{v.estimatedTotalLaps}</td>
+                  <td>{v.pitStops}</td>
+                  <td>{formatLapTime(v.avgPace)}</td>
+                  <td data-testid={`pit-time-${i}`}>{v.totalPitTimeSec != null ? formatPitTime(v.totalPitTimeSec) : '—'}</td>
+                  <td>{v.feasible ? <span className="badge active">Feasible</span> : <span className="badge warning" data-testid="feasibility-warning">{shortfallText}</span>}</td>
+                  <td><button className="btn-primary btn-sm" data-testid={`activate-variant-${i}`} onClick={() => handleActivate(v.id)} disabled={activating}>Use this</button></td>
                 </tr>
-              )}
-            </React.Fragment>
-          ))}
+                {expanded === i && (
+                  <tr className="detail-row" data-testid={`variant-detail-${i}`}>
+                    <td colSpan="7">
+                      <div className="stint-detail">
+                        {v.fuelSaveTargets && (
+                          <div className="fuel-save-targets" data-testid="fuel-save-targets">
+                            <h4>Fuel Save Targets</h4>
+                            {v.fuelSaveTargets.map(t => (
+                              <div key={t.driverId}>{t.driverName}: {t.targetFuelPerLap.toFixed(2)} L/lap fuel, max pace loss {t.maxPaceLoss}</div>
+                            ))}
+                          </div>
+                        )}
+                        {!v.feasible && <div className="warning-box" data-testid="tyre-warning">Warning: Tyre supply insufficient. {shortfallText}.</div>}
+                        <table className="stint-table" data-testid="stint-table">
+                          <thead>
+                            <tr><th>#</th><th>Driver</th><th>Start Lap</th><th>End Lap</th><th>Fuel Load</th><th>Tyre Change</th><th>Est. Start</th><th>Pit Time</th></tr>
+                          </thead>
+                          <tbody>
+                            {v.stints.map(s => (
+                              <tr key={s.stintNumber}>
+                                <td>{s.stintNumber}</td>
+                                <td>{s.driverName}</td>
+                                <td>{s.plannedStartLap}</td>
+                                <td>{s.plannedEndLap}</td>
+                                <td>{s.fuelLoad}%</td>
+                                <td>{s.tyresChanged > 0 ? `Yes (${s.tyresChanged})` : 'No'}</td>
+                                <td>{s.estimatedStartTime ? new Date(s.estimatedStartTime).toLocaleTimeString() : '—'}</td>
+                                <td>{s.estimatedPitTime ? `${s.estimatedPitTime.toFixed(1)}s` : '—'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
         </tbody>
       </table>
 

--- a/client/src/pages/StrategyCreate.jsx
+++ b/client/src/pages/StrategyCreate.jsx
@@ -27,7 +27,8 @@ export default function StrategyCreate() {
   const [tyreDegRR, setTyreDegRR] = useState('');
   const [estimatedTotalLaps, setEstimatedTotalLaps] = useState('');
   const [tyreMultiplicity, setTyreMultiplicity] = useState(1);
-  const [tyreMultiplicityRecommendation, setTyreMultiplicityRecommendation] = useState(null);
+  const [tyreMultiplicityRecommendation, setTyreMultiplicityRecommendation] = useState(restoredValues?.tyreMultiplicityRecommendation ?? null);
+  const [derivedLapsNull, setDerivedLapsNull] = useState(false);
   const [error, setError] = useState('');
   const [calculating, setCalculating] = useState(false);
 
@@ -62,6 +63,7 @@ export default function StrategyCreate() {
           setTyreDegRR(String(r.tyre_deg_rr));
 
           const derived = deriveLaps(driverList, r.duration_hours);
+          if (derived === null) setDerivedLapsNull(true);
           const lapsValue = derived ? String(derived) : (r.estimated_total_laps ? String(r.estimated_total_laps) : '');
           setEstimatedTotalLaps(lapsValue);
         })
@@ -96,10 +98,8 @@ export default function StrategyCreate() {
         estimatedTotalLaps: laps,
         tyreMultiplicity: parseInt(tyreMultiplicity),
       });
-      if (variants.length > 0 && variants[0].tyreMultiplicityRecommendation) {
-        setTyreMultiplicityRecommendation(variants[0].tyreMultiplicityRecommendation);
-      }
-      navigate(`/races/${id}/strategy/compare`, { state: { variants, formValues: { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps, tyreMultiplicity } } });
+      const recommendation = (variants.length > 0 && variants[0].tyreMultiplicityRecommendation) ? variants[0].tyreMultiplicityRecommendation : null;
+      navigate(`/races/${id}/strategy/compare`, { state: { variants, formValues: { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps, tyreMultiplicity, tyreMultiplicityRecommendation: recommendation } } });
     } catch (err) {
       setError(err.message);
     } finally {
@@ -139,6 +139,7 @@ export default function StrategyCreate() {
           <div className="form-group">
             <label>Est. Total Laps</label>
             <input type="number" data-testid="strategy-laps-input" value={estimatedTotalLaps} onChange={e => setEstimatedTotalLaps(e.target.value)} min="1" />
+            {derivedLapsNull && <span className="warning" data-testid="derived-laps-warning">No valid driver paces — enter laps manually</span>}
           </div>
         </div>
 
@@ -156,7 +157,6 @@ export default function StrategyCreate() {
               <option value={1}>Every stop</option>
               <option value={2}>Every 2nd stop</option>
               <option value={3}>Every 3rd stop</option>
-              <option value={4}>Every 4th stop</option>
             </select>
             {tyreMultiplicityRecommendation && (
               <span className="hint" data-testid="tyre-multiplicity-hint">

--- a/client/src/pages/StrategyCreate.jsx
+++ b/client/src/pages/StrategyCreate.jsx
@@ -1,10 +1,19 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { races, strategies } from '../api';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { races, strategies, drivers as driversApi } from '../api';
+
+function deriveLaps(driverList, durationHours) {
+  if (!driverList || driverList.length === 0) return null;
+  const avg = driverList.reduce((sum, d) => sum + d.avg_lap_time_ms, 0) / driverList.length;
+  if (!avg || avg <= 0) return null;
+  return Math.floor(durationHours * 3600 * 1000 / avg);
+}
 
 export default function StrategyCreate() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const restoredValues = location.state?.formValues || null;
   const [race, setRace] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -17,21 +26,48 @@ export default function StrategyCreate() {
   const [tyreDegRL, setTyreDegRL] = useState('');
   const [tyreDegRR, setTyreDegRR] = useState('');
   const [estimatedTotalLaps, setEstimatedTotalLaps] = useState('');
+  const [tyreMultiplicity, setTyreMultiplicity] = useState(1);
+  const [tyreMultiplicityRecommendation, setTyreMultiplicityRecommendation] = useState(null);
   const [error, setError] = useState('');
   const [calculating, setCalculating] = useState(false);
 
   useEffect(() => {
-    races.get(id).then(r => {
-      setRace(r);
-      setName(`${r.name} Strategy`);
-      setFuelPerLap(String(r.fuel_per_lap));
-      setEnergyPerLap(String(r.energy_per_lap));
-      setTyreDegFL(String(r.tyre_deg_fl));
-      setTyreDegFR(String(r.tyre_deg_fr));
-      setTyreDegRL(String(r.tyre_deg_rl));
-      setTyreDegRR(String(r.tyre_deg_rr));
-      setEstimatedTotalLaps(r.estimated_total_laps ? String(r.estimated_total_laps) : '');
-    }).catch(err => setError(err.message)).finally(() => setLoading(false));
+    if (restoredValues) {
+      races.get(id)
+        .then(r => {
+          setRace(r);
+          setName(restoredValues.name ?? `${r.name} Strategy`);
+          setStartTime(restoredValues.startTime ?? '');
+          setFuelPerLap(restoredValues.fuelPerLap ?? String(r.fuel_per_lap));
+          setEnergyPerLap(restoredValues.energyPerLap ?? String(r.energy_per_lap));
+          setTyreDegFL(restoredValues.tyreDegFL ?? String(r.tyre_deg_fl));
+          setTyreDegFR(restoredValues.tyreDegFR ?? String(r.tyre_deg_fr));
+          setTyreDegRL(restoredValues.tyreDegRL ?? String(r.tyre_deg_rl));
+          setTyreDegRR(restoredValues.tyreDegRR ?? String(r.tyre_deg_rr));
+          setEstimatedTotalLaps(restoredValues.estimatedTotalLaps ?? '');
+          if (restoredValues.tyreMultiplicity != null) setTyreMultiplicity(restoredValues.tyreMultiplicity);
+        })
+        .catch(err => setError(err.message))
+        .finally(() => setLoading(false));
+    } else {
+      Promise.all([races.get(id), driversApi.list(id)])
+        .then(([r, driverList]) => {
+          setRace(r);
+          setName(`${r.name} Strategy`);
+          setFuelPerLap(String(r.fuel_per_lap));
+          setEnergyPerLap(String(r.energy_per_lap));
+          setTyreDegFL(String(r.tyre_deg_fl));
+          setTyreDegFR(String(r.tyre_deg_fr));
+          setTyreDegRL(String(r.tyre_deg_rl));
+          setTyreDegRR(String(r.tyre_deg_rr));
+
+          const derived = deriveLaps(driverList, r.duration_hours);
+          const lapsValue = derived ? String(derived) : (r.estimated_total_laps ? String(r.estimated_total_laps) : '');
+          setEstimatedTotalLaps(lapsValue);
+        })
+        .catch(err => setError(err.message))
+        .finally(() => setLoading(false));
+    }
   }, [id]);
 
   async function handleCalculate(e) {
@@ -58,8 +94,12 @@ export default function StrategyCreate() {
         tyreDegRL: parseFloat(tyreDegRL),
         tyreDegRR: parseFloat(tyreDegRR),
         estimatedTotalLaps: laps,
+        tyreMultiplicity: parseInt(tyreMultiplicity),
       });
-      navigate(`/races/${id}/strategy/compare`, { state: { variants, formValues: { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps } } });
+      if (variants.length > 0 && variants[0].tyreMultiplicityRecommendation) {
+        setTyreMultiplicityRecommendation(variants[0].tyreMultiplicityRecommendation);
+      }
+      navigate(`/races/${id}/strategy/compare`, { state: { variants, formValues: { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps, tyreMultiplicity } } });
     } catch (err) {
       setError(err.message);
     } finally {
@@ -107,6 +147,23 @@ export default function StrategyCreate() {
           <div className="form-group"><label>Tyre Deg FR (%/lap)</label><input type="number" data-testid="strategy-tyre-fr-input" value={tyreDegFR} onChange={e => setTyreDegFR(e.target.value)} min="0" max="100" step="0.01" /></div>
           <div className="form-group"><label>Tyre Deg RL (%/lap)</label><input type="number" data-testid="strategy-tyre-rl-input" value={tyreDegRL} onChange={e => setTyreDegRL(e.target.value)} min="0" max="100" step="0.01" /></div>
           <div className="form-group"><label>Tyre Deg RR (%/lap)</label><input type="number" data-testid="strategy-tyre-rr-input" value={tyreDegRR} onChange={e => setTyreDegRR(e.target.value)} min="0" max="100" step="0.01" /></div>
+        </div>
+
+        <div className="form-row">
+          <div className="form-group">
+            <label>Tyre Change Frequency</label>
+            <select data-testid="tyre-multiplicity-select" value={tyreMultiplicity} onChange={e => setTyreMultiplicity(parseInt(e.target.value))}>
+              <option value={1}>Every stop</option>
+              <option value={2}>Every 2nd stop</option>
+              <option value={3}>Every 3rd stop</option>
+              <option value={4}>Every 4th stop</option>
+            </select>
+            {tyreMultiplicityRecommendation && (
+              <span className="hint" data-testid="tyre-multiplicity-hint">
+                Recommended: every {tyreMultiplicityRecommendation} stop(s)
+              </span>
+            )}
+          </div>
         </div>
 
         <div className="form-actions">

--- a/e2e/features/epic-3-strategy-creation.feature
+++ b/e2e/features/epic-3-strategy-creation.feature
@@ -28,7 +28,7 @@ Feature: Strategy Creation (Two-Step Flow)
     When I navigate to the strategy creation page
     Then the strategy fuel per lap should be "3.5"
     And the strategy energy per lap should be "2.1"
-    And the estimated total laps should be "380"
+    And the estimated total laps should be "421"
 
   Scenario: Validation blocks calculation with invalid inputs
     When I navigate to the strategy creation page

--- a/server/engine/strategy.js
+++ b/server/engine/strategy.js
@@ -14,12 +14,13 @@ function calculateStintLength({ fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, 
   return Math.min(...limits);
 }
 
-function generateStintPlan({ drivers, estimatedTotalLaps, stintLength, startLap = 1, availableTyres, avgPitFuel = 100, startTime = null, avgLapTimeMs = null }) {
+function generateStintPlan({ drivers, estimatedTotalLaps, stintLength, startLap = 1, availableTyres, avgPitFuel = 100, startTime = null, avgLapTimeMs = null, tyreMultiplicity = 1 }) {
   const stints = [];
   let currentLap = startLap;
   let driverIndex = 0;
   let tyresUsed = 0;
   let stintNumber = 1;
+  let pitStopIndex = 0;
 
   const totalLaps = Math.min(estimatedTotalLaps, MAX_LAPS);
   const effectiveStintLength = Math.max(1, stintLength);
@@ -31,7 +32,8 @@ function generateStintPlan({ drivers, estimatedTotalLaps, stintLength, startLap 
     const endLap = currentLap + lapsThisStint - 1;
 
     const isLastStint = endLap >= totalLaps;
-    const tyresChanged = isLastStint ? 0 : 4;
+    const changeTyresThisPit = !isLastStint && (pitStopIndex % tyreMultiplicity === 0);
+    const tyresChanged = changeTyresThisPit ? 4 : 0;
     if (tyresChanged > 0) tyresUsed += tyresChanged;
 
     const pitTime = isLastStint ? 0 : calculatePitTime({ fuelAdded: avgPitFuel, tyresChanged, damageType: 'none' });
@@ -60,6 +62,7 @@ function generateStintPlan({ drivers, estimatedTotalLaps, stintLength, startLap 
     currentLap = endLap + 1;
     driverIndex++;
     stintNumber++;
+    if (!isLastStint) pitStopIndex++;
   }
 
   return { stints, tyresUsed, feasible: tyresUsed <= availableTyres };
@@ -77,6 +80,7 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
 
   const estimatedTotalLaps = overrides.estimatedTotalLaps ?? race.estimated_total_laps;
   const availableTyres = race.available_tyres;
+  const tyreMultiplicity = overrides.tyreMultiplicity ?? 1;
 
   const avgLapTimeMs = drivers.length > 0
     ? drivers.reduce((sum, d) => sum + d.avg_lap_time_ms, 0) / drivers.length
@@ -87,11 +91,26 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
   const fuelSaveStintLength = calculateStintLength(fuelSaveParams);
   const mixedStintLength = Math.floor((normalStintLength + fuelSaveStintLength) / 2);
 
-  const commonOpts = { drivers, estimatedTotalLaps, availableTyres, startTime, avgLapTimeMs };
+  const commonOpts = { drivers, estimatedTotalLaps, availableTyres, startTime, avgLapTimeMs, tyreMultiplicity };
 
   const normalPlan = generateStintPlan({ ...commonOpts, stintLength: normalStintLength });
   const fuelSavePlan = generateStintPlan({ ...commonOpts, stintLength: fuelSaveStintLength });
   const mixedPlan = generateStintPlan({ ...commonOpts, stintLength: mixedStintLength });
+
+  const pitTimePerStop = calculatePitTime({ fuelAdded: 100, tyresChanged: 4, damageType: 'none' });
+  const pitTimeNoTyres = calculatePitTime({ fuelAdded: 100, tyresChanged: 0, damageType: 'none' });
+
+  function computeTotalPitTimeSec(plan) {
+    return plan.stints.reduce((sum, s) => sum + (s.estimatedPitTime || 0), 0);
+  }
+
+  function computeRequiredTyreSets(plan) {
+    return plan.tyresUsed / 4;
+  }
+
+  const tyreMultiplicityRecommendation = availableTyres > 0
+    ? Math.ceil((normalPlan.stints.length - 1) / (availableTyres / 4))
+    : 1;
 
   const variants = [
     {
@@ -102,6 +121,10 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       estimatedTotalLaps,
       pitStops: normalPlan.stints.length - 1,
       avgPace: avgLapTimeMs,
+      totalPitTimeSec: computeTotalPitTimeSec(normalPlan),
+      requiredTyreSets: computeRequiredTyreSets(normalPlan),
+      availableTyres,
+      tyreMultiplicityRecommendation,
     },
     {
       name: 'Fuel Save',
@@ -111,6 +134,10 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       estimatedTotalLaps,
       pitStops: fuelSavePlan.stints.length - 1,
       avgPace: avgLapTimeMs ? Math.round(avgLapTimeMs * 1.02) : null,
+      totalPitTimeSec: computeTotalPitTimeSec(fuelSavePlan),
+      requiredTyreSets: computeRequiredTyreSets(fuelSavePlan),
+      availableTyres,
+      tyreMultiplicityRecommendation,
       fuelSaveTargets: drivers.map(d => ({
         driverId: d.id,
         driverName: d.name,
@@ -127,6 +154,10 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       estimatedTotalLaps,
       pitStops: mixedPlan.stints.length - 1,
       avgPace: avgLapTimeMs ? Math.round(avgLapTimeMs * 1.01) : null,
+      totalPitTimeSec: computeTotalPitTimeSec(mixedPlan),
+      requiredTyreSets: computeRequiredTyreSets(mixedPlan),
+      availableTyres,
+      tyreMultiplicityRecommendation,
     },
   ];
 
@@ -142,6 +173,9 @@ function recalculateFromLap({ race, drivers, strategy, confirmedStints, currentL
     tyreDegRL: strategy.tyre_deg_rl || race.tyre_deg_rl,
     tyreDegRR: strategy.tyre_deg_rr || race.tyre_deg_rr,
   };
+
+  const strategyData = strategy.data ? (typeof strategy.data === 'string' ? JSON.parse(strategy.data) : strategy.data) : {};
+  const tyreMultiplicity = strategyData.tyreMultiplicity ?? 1;
 
   const estimatedTotalLaps = race.estimated_total_laps;
   const stintLength = calculateStintLength(params);
@@ -170,6 +204,7 @@ function recalculateFromLap({ race, drivers, strategy, confirmedStints, currentL
     availableTyres: remainingTyres,
     startTime,
     avgLapTimeMs,
+    tyreMultiplicity,
   });
 
   plan.stints = plan.stints.map((s, i) => ({

--- a/server/engine/strategy.js
+++ b/server/engine/strategy.js
@@ -97,9 +97,6 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
   const fuelSavePlan = generateStintPlan({ ...commonOpts, stintLength: fuelSaveStintLength });
   const mixedPlan = generateStintPlan({ ...commonOpts, stintLength: mixedStintLength });
 
-  const pitTimePerStop = calculatePitTime({ fuelAdded: 100, tyresChanged: 4, damageType: 'none' });
-  const pitTimeNoTyres = calculatePitTime({ fuelAdded: 100, tyresChanged: 0, damageType: 'none' });
-
   function computeTotalPitTimeSec(plan) {
     return plan.stints.reduce((sum, s) => sum + (s.estimatedPitTime || 0), 0);
   }
@@ -124,6 +121,7 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       totalPitTimeSec: computeTotalPitTimeSec(normalPlan),
       requiredTyreSets: computeRequiredTyreSets(normalPlan),
       availableTyres,
+      tyreMultiplicity,
       tyreMultiplicityRecommendation,
     },
     {
@@ -137,6 +135,7 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       totalPitTimeSec: computeTotalPitTimeSec(fuelSavePlan),
       requiredTyreSets: computeRequiredTyreSets(fuelSavePlan),
       availableTyres,
+      tyreMultiplicity,
       tyreMultiplicityRecommendation,
       fuelSaveTargets: drivers.map(d => ({
         driverId: d.id,
@@ -157,6 +156,7 @@ function generateVariants({ race, drivers, startTime, overrides = {} }) {
       totalPitTimeSec: computeTotalPitTimeSec(mixedPlan),
       requiredTyreSets: computeRequiredTyreSets(mixedPlan),
       availableTyres,
+      tyreMultiplicity,
       tyreMultiplicityRecommendation,
     },
   ];

--- a/server/routes/strategies.js
+++ b/server/routes/strategies.js
@@ -15,7 +15,8 @@ router.post('/:raceId/calculate', (req, res) => {
     return res.status(400).json({ error: 'Race must have at least one driver' });
   }
 
-  const { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, estimatedTotalLaps } = req.body;
+  const { name, startTime, fuelPerLap, energyPerLap, tyreDegFL, tyreDegFR, tyreDegRL, tyreDegRR, tyreMultiplicity } = req.body;
+  let { estimatedTotalLaps } = req.body;
 
   if (fuelPerLap !== undefined && (fuelPerLap < 0 || fuelPerLap > 200)) {
     return res.status(400).json({ error: 'Fuel per lap must be 0-200 L' });
@@ -29,7 +30,16 @@ router.post('/:raceId/calculate', (req, res) => {
       return res.status(400).json({ error: 'Tyre wear must be 0-100' });
     }
   }
-  if (estimatedTotalLaps !== undefined && estimatedTotalLaps <= 0) {
+
+  if (estimatedTotalLaps === undefined || estimatedTotalLaps === null) {
+    const avgLapTimeMs = drivers.reduce((sum, d) => sum + d.avg_lap_time_ms, 0) / drivers.length;
+    if (!avgLapTimeMs || avgLapTimeMs <= 0) {
+      return res.status(400).json({ error: 'Cannot derive estimated total laps: no valid driver paces' });
+    }
+    estimatedTotalLaps = Math.floor(race.duration_hours * 3600 * 1000 / avgLapTimeMs);
+  }
+
+  if (estimatedTotalLaps <= 0) {
     return res.status(400).json({ error: 'Estimated total laps must be > 0' });
   }
 
@@ -41,6 +51,7 @@ router.post('/:raceId/calculate', (req, res) => {
   if (tyreDegRL !== undefined) overrides.tyreDegRL = tyreDegRL;
   if (tyreDegRR !== undefined) overrides.tyreDegRR = tyreDegRR;
   if (estimatedTotalLaps !== undefined) overrides.estimatedTotalLaps = estimatedTotalLaps;
+  if (tyreMultiplicity !== undefined) overrides.tyreMultiplicity = tyreMultiplicity;
 
   const variants = generateVariants({ race, drivers, startTime, overrides });
 
@@ -60,7 +71,7 @@ router.post('/:raceId/calculate', (req, res) => {
       overrides.tyreDegFR ?? race.tyre_deg_fr,
       overrides.tyreDegRL ?? race.tyre_deg_rl,
       overrides.tyreDegRR ?? race.tyre_deg_rr,
-      overrides.estimatedTotalLaps ?? race.estimated_total_laps,
+      estimatedTotalLaps,
       JSON.stringify(v)
     );
     return { id: result.lastInsertRowid, ...v };


### PR DESCRIPTION
## Summary
- Tyre multiplicity: schedule tyre changes every N pit stops, reducing tyre set consumption
- Auto-derive estimatedTotalLaps from driver paces (frontend pre-fill + server fallback)
- Add Time in pits (est.) column to strategy comparison table
- Replace generic Tyre shortage badge with specific shortfall text
- Fix floating-point lap-time formatting bug

## Changes
- server/engine/strategy.js: generateStintPlan gains tyreMultiplicity param; generateVariants outputs totalPitTimeSec, requiredTyreSets, availableTyres, tyreMultiplicityRecommendation; recalculateFromLap reads tyreMultiplicity from strategy data JSON
- server/routes/strategies.js: derives estimatedTotalLaps from driver avg pace when absent; threads tyreMultiplicity override to engine
- client/src/pages/StrategyCreate.jsx: fetches drivers on load to pre-fill derived laps; adds tyre-change-frequency select with recommendation hint
- client/src/pages/StrategyCompare.jsx: adds Time in pits (est.) column, specific tyre shortfall text, fixes formatLapTime with Math.round
- e2e/features/epic-3-strategy-creation.feature: updates expected derived laps from 380 to 421

## Testing
- npm test: all 12 strategy engine and pit-time unit tests pass
- npm run test:e2e: epic-3 pre-fill scenario updated to expect 421 (auto-derived from 24h / avg driver pace)
- Manual: laps pre-fill, tyre multiplicity selector, pit-time column, shortfall message

Closes #16