### PR TITLE
feat(auth): gate registration behind a server-side registration code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Required: secret token that must be provided during user registration
+REGISTRATION_CODE=change-me
+
+# Required: secret used to sign session cookies
+SESSION_SECRET=change-me

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -18,7 +18,7 @@ async function request(path, options = {}) {
 
 export const auth = {
   login: (email, password) => request('/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
-  register: (email, password) => request('/auth/register', { method: 'POST', body: JSON.stringify({ email, password }) }),
+  register: (email, password, registrationCode) => request('/auth/register', { method: 'POST', body: JSON.stringify({ email, password, registrationCode }) }),
   logout: () => request('/auth/logout', { method: 'POST' }),
   me: () => request('/auth/me'),
 };

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -4,6 +4,7 @@ import { auth } from '../api';
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [registrationCode, setRegistrationCode] = useState('');
   const [isRegister, setIsRegister] = useState(false);
   const [error, setError] = useState('');
 
@@ -12,7 +13,7 @@ export default function Login({ onLogin }) {
     setError('');
     try {
       const user = isRegister
-        ? await auth.register(email, password)
+        ? await auth.register(email, password, registrationCode)
         : await auth.login(email, password);
       onLogin(user);
     } catch (err) {
@@ -29,6 +30,9 @@ export default function Login({ onLogin }) {
         <form onSubmit={handleSubmit}>
           <input type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} required />
           <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} required minLength={6} />
+          {isRegister && (
+            <input type="text" placeholder="Registration Code" value={registrationCode} onChange={e => setRegistrationCode(e.target.value)} required data-testid="registration-code-input" />
+          )}
           <button type="submit">{isRegister ? 'Register' : 'Login'}</button>
         </form>
         <p className="toggle" onClick={() => setIsRegister(!isRegister)}>

--- a/e2e/support/auth.js
+++ b/e2e/support/auth.js
@@ -7,7 +7,7 @@ Given('I am logged in as {string}', async function (email) {
   await fetch(`${this.apiUrl}/api/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ email, password, registrationCode: process.env.REGISTRATION_CODE || '' }),
   });
 
   // Login via API to get cookie

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,11 @@ const path = require('path');
 
 require('./db/migrate');
 
+if (!process.env.REGISTRATION_CODE) {
+  console.error('FATAL: REGISTRATION_CODE environment variable is not set');
+  process.exit(1);
+}
+
 const authRoutes = require('./routes/auth');
 const racesRoutes = require('./routes/races');
 const strategiesRoutes = require('./routes/strategies');

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,11 +1,17 @@
 const { Router } = require('express');
 const bcrypt = require('bcrypt');
+const crypto = require('crypto');
 const db = require('../db');
 
 const router = Router();
 
 router.post('/register', async (req, res) => {
-  const { email, password } = req.body;
+  const { email, password, registrationCode } = req.body;
+  const expected = Buffer.from(process.env.REGISTRATION_CODE || '', 'utf8');
+  const provided = Buffer.from(registrationCode || '', 'utf8');
+  if (expected.length !== provided.length || !crypto.timingSafeEqual(expected, provided)) {
+    return res.status(403).json({ error: 'Invalid registration code' });
+  }
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password are required' });
   }

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,6 +1,8 @@
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 
+process.env.REGISTRATION_CODE = 'testcode';
+
 const BASE_URL = 'http://localhost:3001';
 
 describe('Auth API', () => {
@@ -15,7 +17,7 @@ describe('Auth API', () => {
     const res = await fetch(`${BASE_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'test@example.com', password: 'password123' }),
+      body: JSON.stringify({ email: 'test@example.com', password: 'password123', registrationCode: 'testcode' }),
     });
     assert.strictEqual(res.status, 201);
     const data = await res.json();
@@ -27,7 +29,7 @@ describe('Auth API', () => {
     const res = await fetch(`${BASE_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'test@example.com', password: 'password123' }),
+      body: JSON.stringify({ email: 'test@example.com', password: 'password123', registrationCode: 'testcode' }),
     });
     assert.strictEqual(res.status, 409);
   });
@@ -36,7 +38,38 @@ describe('Auth API', () => {
     const res = await fetch(`${BASE_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'short@example.com', password: '123' }),
+      body: JSON.stringify({ email: 'short@example.com', password: '123', registrationCode: 'testcode' }),
+    });
+    assert.strictEqual(res.status, 400);
+  });
+
+  test('POST /api/auth/register rejects missing registration code', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'newuser@example.com', password: 'password123' }),
+    });
+    assert.strictEqual(res.status, 403);
+    const data = await res.json();
+    assert.strictEqual(data.error, 'Invalid registration code');
+  });
+
+  test('POST /api/auth/register rejects wrong registration code', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'newuser@example.com', password: 'password123', registrationCode: 'wrongcode' }),
+    });
+    assert.strictEqual(res.status, 403);
+    const data = await res.json();
+    assert.strictEqual(data.error, 'Invalid registration code');
+  });
+
+  test('POST /api/auth/register with correct code but short password returns 400', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'newuser@example.com', password: '123', registrationCode: 'testcode' }),
     });
     assert.strictEqual(res.status, 400);
   });


### PR DESCRIPTION
## Summary
- Add `REGISTRATION_CODE` environment variable guard to `POST /register` — checked via `crypto.timingSafeEqual` before any DB access
- Server exits at startup with a fatal error if `REGISTRATION_CODE` is absent
- Login page shows a registration code input field only when the user switches to the register form
- E2E test helper and unit tests updated to supply the registration code

## Changes
- `server/routes/auth.js` — import `crypto`, destructure `registrationCode` from request body, reject with 403 if code is missing or wrong (timing-safe comparison)
- `server/index.js` — startup guard: `process.exit(1)` if `REGISTRATION_CODE` is not set
- `client/src/api.js` — `auth.register` gains a third `registrationCode` parameter forwarded in the JSON body
- `client/src/pages/Login.jsx` — add `registrationCode` state and a `data-testid="registration-code-input"` field rendered only when `isRegister === true`
- `server/tests/auth.test.js` — set `process.env.REGISTRATION_CODE = 'testcode'` in setup; add `registrationCode` to all register calls; add three new test cases (missing code → 403, wrong code → 403, correct code + short password → 400)
- `e2e/support/auth.js` — pass `registrationCode: process.env.REGISTRATION_CODE` when registering test users
- `.env.example` — document `REGISTRATION_CODE` and `SESSION_SECRET`

## Testing
- Unit tests: `REGISTRATION_CODE=testcode node --test server/tests/strategy.test.js server/tests/auth.test.js` → 22/22 pass
- E2E tests: `REGISTRATION_CODE=testcode npm run test:e2e` → 46/46 scenarios pass (requires backend and frontend running)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)