### PR TITLE
feat(ui): WEC/LMU-inspired dark theme redesign (Epic 9)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LMU Endurance Strategy</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/PageCard.jsx
+++ b/client/src/components/PageCard.jsx
@@ -1,0 +1,3 @@
+export default function PageCard({ children, className = '', ...rest }) {
+  return <div className={`page-card ${className}`.trim()} {...rest}>{children}</div>;
+}

--- a/client/src/components/StatusBadge.jsx
+++ b/client/src/components/StatusBadge.jsx
@@ -1,0 +1,3 @@
+export default function StatusBadge({ variant, children, ...rest }) {
+  return <span className={`badge badge-${variant}`} {...rest}>{children}</span>;
+}

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,3 +1,5 @@
+export const DRIVER_COLORS = ['#3b82f6', '#22c55e', '#f59e0b', '#8b5cf6', '#06b6d4', '#f97316'];
+
 export const TRACKS = [
   'Algarve International Circuit (Portimão)',
   'Autodromo Internazionale Enzo e Dino Ferrari (Imola)',

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import './tokens.css';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { races } from '../api';
+import StatusBadge from '../components/StatusBadge';
 
 export default function Dashboard() {
   const [raceList, setRaceList] = useState([]);
@@ -50,9 +51,9 @@ export default function Dashboard() {
                 <span data-testid="race-drivers">{race.driver_count} driver{race.driver_count !== 1 ? 's' : ''}</span>
               </div>
               <div className="race-status">
-                <span className={race.has_active_strategy ? 'badge active' : 'badge'} data-testid="race-strategy-badge">
+                <StatusBadge variant={race.has_active_strategy ? 'active' : 'planned'} data-testid="race-strategy-badge">
                   {race.has_active_strategy ? 'Strategy Active' : 'No Strategy'}
-                </span>
+                </StatusBadge>
                 <span className="event-count" data-testid="race-events">{race.event_count} event{race.event_count !== 1 ? 's' : ''}</span>
               </div>
               <button

--- a/client/src/pages/RaceCreate.jsx
+++ b/client/src/pages/RaceCreate.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { races } from '../api';
 import { TRACKS } from '../constants';
+import PageCard from '../components/PageCard';
 
 export default function RaceCreate() {
   const navigate = useNavigate();
@@ -100,7 +101,7 @@ export default function RaceCreate() {
   }
 
   return (
-    <div className="race-create" data-testid="race-create-page">
+    <PageCard className="race-create" data-testid="race-create-page">
       <h2>Create New Race</h2>
       {error && <div className="error">{error}</div>}
       <form onSubmit={handleSubmit}>
@@ -189,6 +190,6 @@ export default function RaceCreate() {
           <button type="submit" className="btn-primary" data-testid="submit-race-btn">Create Race</button>
         </div>
       </form>
-    </div>
+    </PageCard>
   );
 }

--- a/client/src/pages/RaceExecution.jsx
+++ b/client/src/pages/RaceExecution.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { races, stints as stintsApi, drivers as driversApi } from '../api';
+import { DRIVER_COLORS } from '../constants';
 
 const DAMAGE_OPTIONS = [
   { value: 'none', label: 'None' },
@@ -88,8 +89,7 @@ export default function RaceExecution() {
   const upcomingStints = futureStints.slice(1, 6);
 
   const driverColors = {};
-  const colors = ['#4f46e5', '#059669', '#d97706', '#dc2626', '#7c3aed', '#0891b2'];
-  driverList.forEach((d, i) => { driverColors[d.id] = colors[i % colors.length]; });
+  driverList.forEach((d, i) => { driverColors[d.id] = DRIVER_COLORS[i % DRIVER_COLORS.length]; });
 
   return (
     <div className="race-execution" data-testid="race-execution-page">

--- a/client/src/pages/StrategyCompare.jsx
+++ b/client/src/pages/StrategyCompare.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { strategies } from '../api';
+import PageCard from '../components/PageCard';
+import StatusBadge from '../components/StatusBadge';
 
 function formatLapTime(ms) {
   if (!ms) return '—';
@@ -60,7 +62,7 @@ export default function StrategyCompare() {
 
   if (variants.length === 0) {
     return (
-      <div className="strategy-compare" data-testid="strategy-compare-page">
+      <PageCard className="strategy-compare" data-testid="strategy-compare-page">
         <h2>Strategy — Step 2: Compare</h2>
         {allInfeasible
           ? <p data-testid="all-infeasible-message">No feasible strategy variant can be produced with the current tyre stock. Increase available tyres in the race settings or adjust tyre wear inputs.</p>
@@ -69,14 +71,14 @@ export default function StrategyCompare() {
         <div className="form-actions">
           <button className="btn-secondary" data-testid="back-to-step1" onClick={() => navigate(`/races/${id}/strategy/new`, { state: { formValues } })}>Back to Step 1</button>
         </div>
-      </div>
+      </PageCard>
     );
   }
 
   const baselinePitTimeSec = variants[0].totalPitTimeSec;
 
   return (
-    <div className="strategy-compare" data-testid="strategy-compare-page">
+    <PageCard className="strategy-compare" data-testid="strategy-compare-page">
       <h2>Strategy — Step 2: Compare & Choose</h2>
 
       <table className="compare-table" data-testid="compare-table">
@@ -155,6 +157,6 @@ export default function StrategyCompare() {
       <div className="form-actions">
         <button className="btn-secondary" data-testid="back-to-step1" onClick={() => navigate(`/races/${id}/strategy/new`, { state: { formValues } })}>Back to Step 1</button>
       </div>
-    </div>
+    </PageCard>
   );
 }

--- a/client/src/pages/StrategyCreate.jsx
+++ b/client/src/pages/StrategyCreate.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { races, strategies, drivers as driversApi } from '../api';
+import PageCard from '../components/PageCard';
 
 function deriveLaps(driverList, durationHours) {
   if (!driverList || driverList.length === 0) return null;
@@ -112,7 +113,7 @@ export default function StrategyCreate() {
   if (!race) return <div className="error">Race not found</div>;
 
   return (
-    <div className="strategy-create" data-testid="strategy-create-page">
+    <PageCard className="strategy-create" data-testid="strategy-create-page">
       <h2>Strategy — Step 1: Configure</h2>
       <p className="subtitle">Race: {race.name}</p>
       {error && <div className="error" data-testid="strategy-error">{error}</div>}
@@ -158,6 +159,6 @@ export default function StrategyCreate() {
           </button>
         </div>
       </form>
-    </div>
+    </PageCard>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,125 +1,135 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: #0f172a;
-  color: #e2e8f0;
+  font-family: var(--font-family);
+  background: var(--color-bg-base);
+  color: var(--color-text-primary);
   line-height: 1.6;
 }
 
-.loading { display: flex; align-items: center; justify-content: center; min-height: 100vh; color: #94a3b8; }
-.error { background: #7f1d1d; color: #fca5a5; padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1rem; }
+.loading { display: flex; align-items: center; justify-content: center; min-height: 100vh; color: var(--color-text-secondary); }
+.error { background: #3b0a0a; color: #fca5a5; padding: 0.75rem 1rem; border-radius: var(--radius-lg); margin-bottom: 1rem; border: 1px solid var(--color-danger); }
 
 header {
   display: flex; justify-content: space-between; align-items: center;
-  padding: 1rem 2rem; background: #1e293b; border-bottom: 1px solid #334155;
+  padding: 1rem 2rem; background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border);
 }
-header h1 { font-size: 1.25rem; color: #f1f5f9; }
+header h1 { font-size: var(--text-xl); color: var(--color-accent-secondary); font-weight: 700; letter-spacing: 0.02em; }
 .user-info { display: flex; align-items: center; gap: 1rem; }
-.user-info span { color: #94a3b8; font-size: 0.875rem; }
-.user-info button { background: #334155; color: #e2e8f0; border: none; padding: 0.4rem 0.8rem; border-radius: 4px; cursor: pointer; font-size: 0.8rem; }
+.user-info span { color: var(--color-text-secondary); font-size: var(--text-sm); }
+.user-info button { background: var(--color-bg-elevated); color: var(--color-text-primary); border: 1px solid var(--color-border); padding: 0.4rem 0.8rem; border-radius: var(--radius-md); cursor: pointer; font-size: var(--text-xs); transition: background var(--transition-fast); }
+.user-info button:hover { background: var(--color-border); }
 
 main { max-width: 1200px; margin: 2rem auto; padding: 0 2rem; }
 
 /* Login */
 .login-page { display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-.login-card { background: #1e293b; padding: 2.5rem; border-radius: 12px; width: 100%; max-width: 400px; }
-.login-card h1 { margin-bottom: 0.5rem; color: #818cf8; }
-.login-card h2 { margin-bottom: 1.5rem; font-size: 1.1rem; color: #94a3b8; }
+.login-card { background: var(--color-bg-surface); padding: 2.5rem; border-radius: 12px; width: 100%; max-width: 400px; border: 1px solid var(--color-border); }
+.login-card h1 { margin-bottom: 0.5rem; color: var(--color-accent-secondary); }
+.login-card h2 { margin-bottom: 1.5rem; font-size: var(--text-lg); color: var(--color-text-secondary); }
 .login-card form { display: flex; flex-direction: column; gap: 1rem; }
-.login-card input { background: #0f172a; border: 1px solid #475569; color: #e2e8f0; padding: 0.75rem; border-radius: 6px; font-size: 0.9rem; }
-.login-card input:focus { outline: none; border-color: #6366f1; }
-.login-card button { background: #4f46e5; color: white; border: none; padding: 0.75rem; border-radius: 6px; font-size: 1rem; cursor: pointer; }
-.login-card button:hover { background: #4338ca; }
-.login-card .toggle { margin-top: 1rem; text-align: center; color: #818cf8; cursor: pointer; font-size: 0.875rem; }
+.login-card input { background: var(--color-bg-input); border: 1px solid var(--color-border); color: var(--color-text-primary); padding: 0.75rem; border-radius: var(--radius-lg); font-size: var(--text-sm); }
+.login-card input:focus { outline: none; border-color: var(--color-border-focus); }
+.login-card button { background: var(--color-accent); color: var(--color-text-inverse); border: none; padding: 0.75rem; border-radius: var(--radius-lg); font-size: var(--text-base); cursor: pointer; font-weight: 600; transition: background var(--transition-fast); }
+.login-card button:hover { background: var(--color-accent-hover); }
+.login-card .toggle { margin-top: 1rem; text-align: center; color: var(--color-accent-secondary); cursor: pointer; font-size: var(--text-sm); }
 
 /* Buttons */
-button { cursor: pointer; border: none; border-radius: 6px; font-size: 0.875rem; padding: 0.5rem 1rem; transition: all 0.15s; }
-.btn-primary { background: #4f46e5; color: white; }
-.btn-primary:hover { background: #4338ca; }
-.btn-secondary { background: #334155; color: #e2e8f0; }
-.btn-secondary:hover { background: #475569; }
-.btn-danger { background: #991b1b; color: #fca5a5; }
-.btn-danger:hover { background: #7f1d1d; }
-.btn-sm { padding: 0.25rem 0.75rem; font-size: 0.8rem; }
+button { cursor: pointer; border: none; border-radius: var(--radius-lg); font-size: var(--text-sm); padding: 0.5rem 1rem; transition: all var(--transition-fast); }
+.btn-primary { background: var(--color-accent); color: var(--color-text-inverse); font-weight: 600; }
+.btn-primary:hover { background: var(--color-accent-hover); }
+.btn-secondary { background: var(--color-bg-elevated); color: var(--color-text-primary); border: 1px solid var(--color-border); }
+.btn-secondary:hover { background: var(--color-border); }
+.btn-danger { background: #3b0a0a; color: #fca5a5; border: 1px solid var(--color-danger); }
+.btn-danger:hover { background: #5b1010; }
+.btn-sm { padding: 0.25rem 0.75rem; font-size: var(--text-xs); }
 
 /* Badges */
-.badge { display: inline-block; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.75rem; background: #334155; }
-.badge.active { background: #065f46; color: #6ee7b7; }
+.badge { display: inline-block; padding: 0.2rem 0.5rem; border-radius: var(--radius-md); font-size: var(--text-xs); background: var(--color-bg-elevated); color: var(--color-text-secondary); font-weight: 500; }
+.badge.active, .badge-active { background: #052e16; color: var(--color-success); border: 1px solid var(--color-success); }
+.badge.warning, .badge-warning { background: #2d1a00; color: var(--color-warning); border: 1px solid var(--color-warning); }
+.badge-planned { background: var(--color-bg-elevated); color: var(--color-text-muted); border: 1px solid var(--color-border); }
+
+/* Page Card */
+.page-card { background: var(--color-bg-surface); padding: 2rem; border-radius: var(--radius-lg); border: 1px solid var(--color-border); }
+.page-card h2 { margin-bottom: 1.5rem; }
 
 /* Dashboard */
 .dashboard-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
-.empty-state { text-align: center; padding: 3rem; background: #1e293b; border-radius: 12px; }
-.empty-state p { color: #94a3b8; margin-bottom: 1rem; }
+.empty-state { text-align: center; padding: 3rem; background: var(--color-bg-surface); border-radius: 12px; border: 1px solid var(--color-border); }
+.empty-state p { color: var(--color-text-secondary); margin-bottom: 1rem; }
 .race-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
-.race-card { background: #1e293b; padding: 1.25rem; border-radius: 10px; cursor: pointer; transition: transform 0.1s; border: 1px solid #334155; }
-.race-card:hover { transform: translateY(-2px); border-color: #4f46e5; }
+.race-card { background: var(--color-bg-surface); padding: 1.25rem; border-radius: 10px; cursor: pointer; transition: transform var(--transition-fast), border-color var(--transition-fast); border: 1px solid var(--color-border); }
+.race-card:hover { transform: translateY(-2px); border-color: var(--color-accent-secondary); }
 .race-card h3 { margin-bottom: 0.5rem; }
-.race-meta { display: flex; gap: 1rem; font-size: 0.8rem; color: #94a3b8; margin-bottom: 0.5rem; }
+.race-meta { display: flex; gap: 1rem; font-size: var(--text-xs); color: var(--color-text-secondary); margin-bottom: 0.5rem; }
 .race-status { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; }
-.event-count { font-size: 0.75rem; color: #64748b; }
+.event-count { font-size: var(--text-xs); color: var(--color-text-muted); }
 
 /* Forms */
 .form-group { display: flex; flex-direction: column; gap: 0.25rem; margin-bottom: 0.75rem; }
-.form-group label { font-size: 0.8rem; color: #94a3b8; font-weight: 500; }
+.form-group label { font-size: var(--text-xs); color: var(--color-text-secondary); font-weight: 500; text-transform: uppercase; letter-spacing: 0.05em; }
 .form-row { display: flex; gap: 1rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
 .form-row .form-group { flex: 1; min-width: 150px; margin-bottom: 0; }
 .form-section { margin: 1.5rem 0; }
 .form-section h3 { margin-bottom: 0.75rem; }
 .form-actions { display: flex; gap: 1rem; margin-top: 1.5rem; }
-input, select { background: #1e293b; border: 1px solid #475569; color: #e2e8f0; padding: 0.5rem 0.75rem; border-radius: 6px; font-size: 0.9rem; width: 100%; }
-input:focus, select:focus { outline: none; border-color: #6366f1; }
-.field-error { color: #fca5a5; font-size: 0.75rem; }
+input, select { background: var(--color-bg-input); border: 1px solid var(--color-border); color: var(--color-text-primary); padding: 0.5rem 0.75rem; border-radius: var(--radius-lg); font-size: var(--text-sm); width: 100%; transition: border-color var(--transition-fast); }
+input:focus, select:focus { outline: none; border-color: var(--color-border-focus); }
+select option { background: var(--color-bg-input); }
+.field-error { color: #fca5a5; font-size: var(--text-xs); }
 .driver-row { align-items: flex-end; }
+.hint { font-size: var(--text-xs); color: var(--color-text-muted); margin-top: 0.25rem; }
+.warning { color: var(--color-warning); font-size: var(--text-xs); }
 
 /* Race Create */
-.race-create { background: #1e293b; padding: 2rem; border-radius: 12px; }
+.race-create { background: var(--color-bg-surface); padding: 2rem; border-radius: 12px; border: 1px solid var(--color-border); }
 .race-create h2 { margin-bottom: 1.5rem; }
 
 /* Strategy */
-.strategy-create, .strategy-compare { background: #1e293b; padding: 2rem; border-radius: 12px; }
+.strategy-create, .strategy-compare { background: var(--color-bg-surface); padding: 2rem; border-radius: 12px; border: 1px solid var(--color-border); }
 .strategy-create h2, .strategy-compare h2 { margin-bottom: 0.5rem; }
-.subtitle { color: #94a3b8; margin-bottom: 1.5rem; font-size: 0.9rem; }
+.subtitle { color: var(--color-text-secondary); margin-bottom: 1.5rem; font-size: var(--text-sm); }
 .compare-table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
-.compare-table th, .compare-table td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #334155; }
-.compare-table th { color: #94a3b8; font-size: 0.8rem; text-transform: uppercase; }
-.link-btn { background: none; color: #818cf8; text-decoration: underline; padding: 0; border: none; cursor: pointer; }
-.detail-row td { padding: 1rem; background: #0f172a; }
+.compare-table th, .compare-table td { padding: 0.75rem; text-align: left; border-bottom: 1px solid var(--color-border); }
+.compare-table th { color: var(--color-text-secondary); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+.compare-table tr:hover td { background: var(--color-bg-elevated); }
+.link-btn { background: none; color: var(--color-accent-secondary); text-decoration: underline; padding: 0; border: none; cursor: pointer; }
+.detail-row td { padding: 1rem; background: var(--color-bg-base); }
 .stint-detail { overflow-x: auto; }
-.stint-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-.stint-table th, .stint-table td { padding: 0.5rem; border-bottom: 1px solid #1e293b; }
-.stint-table th { color: #94a3b8; }
-.fuel-save-targets { margin-bottom: 1rem; font-size: 0.85rem; color: #fcd34d; }
+.stint-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+.stint-table th, .stint-table td { padding: 0.5rem; border-bottom: 1px solid var(--color-border); }
+.stint-table th { color: var(--color-text-secondary); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.05em; }
+.fuel-save-targets { margin-bottom: 1rem; font-size: var(--text-sm); color: var(--color-warning); }
 .fuel-save-targets h4 { margin-bottom: 0.25rem; }
-.warning-box { background: #78350f; color: #fcd34d; padding: 0.5rem 1rem; border-radius: 6px; margin-bottom: 1rem; }
-.badge.warning { background: #78350f; color: #fcd34d; }
+.warning-box { background: #2d1a00; color: var(--color-warning); padding: 0.5rem 1rem; border-radius: var(--radius-lg); margin-bottom: 1rem; border: 1px solid var(--color-warning); }
 
 /* Race Execution */
 .exec-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
 .exec-actions { display: flex; gap: 0.5rem; }
-.laps-control { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; background: #1e293b; padding: 1rem; border-radius: 8px; }
-.laps-control label { font-size: 0.85rem; color: #94a3b8; white-space: nowrap; }
+.laps-control { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem; background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; border: 1px solid var(--color-border); }
+.laps-control label { font-size: var(--text-sm); color: var(--color-text-secondary); white-space: nowrap; }
 .laps-control input { width: 100px; }
 
-.driver-order { background: #1e293b; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; }
-.driver-order h3 { margin-bottom: 0.75rem; font-size: 0.95rem; }
+.driver-order { background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; border: 1px solid var(--color-border); }
+.driver-order h3 { margin-bottom: 0.75rem; font-size: var(--text-base); }
 .driver-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-.driver-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.75rem; background: #0f172a; border-radius: 6px; }
-.order-controls button { background: #334155; color: #e2e8f0; border: none; padding: 0.2rem 0.4rem; border-radius: 3px; font-size: 0.75rem; cursor: pointer; }
+.driver-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.75rem; background: var(--color-bg-elevated); border-radius: var(--radius-lg); }
+.order-controls button { background: var(--color-bg-elevated); color: var(--color-text-primary); border: 1px solid var(--color-border); padding: 0.2rem 0.4rem; border-radius: var(--radius-sm); font-size: var(--text-xs); cursor: pointer; }
 .order-controls button:disabled { opacity: 0.3; cursor: not-allowed; }
 
-.timeline { background: #1e293b; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; }
-.timeline h3 { margin-bottom: 0.75rem; font-size: 0.95rem; }
-.timeline-bar { display: flex; height: 40px; border-radius: 6px; overflow: hidden; gap: 1px; }
-.timeline-block { transition: opacity 0.2s; }
+.timeline { background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; border: 1px solid var(--color-border); }
+.timeline h3 { margin-bottom: 0.75rem; font-size: var(--text-base); }
+.timeline-bar { display: flex; height: 40px; border-radius: var(--radius-lg); overflow: hidden; gap: 1px; }
+.timeline-block { transition: opacity var(--transition-base); }
 .timeline-block.planned { opacity: 0.5; }
 .timeline-block.confirmed { opacity: 1; }
 .timeline-legend { display: flex; gap: 1rem; margin-top: 0.5rem; flex-wrap: wrap; }
-.legend-item { display: flex; align-items: center; gap: 0.3rem; font-size: 0.8rem; }
-.legend-color { width: 12px; height: 12px; border-radius: 3px; }
+.legend-item { display: flex; align-items: center; gap: 0.3rem; font-size: var(--text-xs); }
+.legend-color { width: 12px; height: 12px; border-radius: var(--radius-sm); }
 
-.changeover-table { background: #1e293b; padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; overflow-x: auto; }
-.changeover-table h3 { margin-bottom: 0.75rem; font-size: 0.95rem; }
+.changeover-table { background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; overflow-x: auto; border: 1px solid var(--color-border); }
+.changeover-table h3 { margin-bottom: 0.75rem; font-size: var(--text-base); }
 .changeover-table .stint-table { table-layout: fixed; }
 .changeover-table .stint-table th:nth-child(1),
 .changeover-table .stint-table td:nth-child(1) { width: 8%; }
@@ -135,18 +145,18 @@ input:focus, select:focus { outline: none; border-color: #6366f1; }
 
 .current-stint, .upcoming-stints, .confirmed-stints, .driver-summary { margin-bottom: 1.5rem; }
 .current-stint h3, .upcoming-stints h3, .confirmed-stints h3, .driver-summary h3 { margin-bottom: 0.75rem; }
-.stint-card { background: #1e293b; padding: 1rem; border-radius: 8px; margin-bottom: 0.5rem; }
-.stint-card.active { border: 1px solid #4f46e5; }
+.stint-card { background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; margin-bottom: 0.5rem; border: 1px solid var(--color-border); }
+.stint-card.active { border: 1px solid var(--color-accent-secondary); }
 .stint-info { display: flex; flex-wrap: wrap; align-items: center; gap: 1rem; }
-.stint-laps { color: #94a3b8; font-size: 0.85rem; }
-.est-time { color: #64748b; font-size: 0.8rem; }
+.stint-laps { color: var(--color-text-secondary); font-size: var(--text-sm); }
+.est-time { color: var(--color-text-muted); font-size: var(--text-xs); }
 .stint-actions { margin-top: 0.75rem; }
-.confirm-form { margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid #334155; }
+.confirm-form { margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--color-border); }
 
 .summary-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 1rem; }
-.summary-card { background: #1e293b; padding: 1rem; border-radius: 8px; }
+.summary-card { background: var(--color-bg-surface); padding: 1rem; border-radius: 8px; border: 1px solid var(--color-border); }
 .summary-card h4 { margin-bottom: 0.5rem; }
-.summary-card div { font-size: 0.85rem; color: #94a3b8; }
+.summary-card div { font-size: var(--text-sm); color: var(--color-text-secondary); }
 
 /* Placeholder */
-.placeholder { text-align: center; padding: 3rem; color: #64748b; font-style: italic; }
+.placeholder { text-align: center; padding: 3rem; color: var(--color-text-muted); font-style: italic; }

--- a/client/src/tokens.css
+++ b/client/src/tokens.css
@@ -1,0 +1,60 @@
+:root {
+  /* Background surfaces */
+  --color-bg-base: #0b0f17;
+  --color-bg-surface: #151c28;
+  --color-bg-elevated: #1d2535;
+  --color-bg-input: #0f1520;
+
+  /* Borders */
+  --color-border: #2a3a52;
+  --color-border-focus: #e8001d;
+
+  /* Text */
+  --color-text-primary: #f0f4fa;
+  --color-text-secondary: #94adc8;
+  --color-text-muted: #5a7a9a;
+  --color-text-inverse: #0b0f17;
+
+  /* Accent */
+  --color-accent: #e8001d;
+  --color-accent-hover: #ff1a35;
+  --color-accent-secondary: #1e90ff;
+
+  /* Semantic */
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #e8001d;
+  --color-info: #1e90ff;
+
+  /* Typography */
+  --font-family: 'Inter', 'Barlow', system-ui, sans-serif;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radii */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-base: 200ms ease;
+}

--- a/e2e/cucumber.js
+++ b/e2e/cucumber.js
@@ -4,4 +4,14 @@ module.exports = {
     require: ['steps/**/*.js', 'support/**/*.js'],
     format: ['progress'],
   },
+  epic8: {
+    paths: ['features/epic-8-registration-code.feature'],
+    require: ['steps/epic-8-registration-code.js', 'support/world.js', 'support/auth.js'],
+    format: ['progress'],
+  },
+  epic9: {
+    paths: ['features/epic-9-ui-redesign.feature'],
+    require: ['steps/epic-9-ui-redesign.js', 'support/world.js', 'support/auth.js'],
+    format: ['progress'],
+  },
 };

--- a/e2e/features/epic-9-ui-redesign.feature
+++ b/e2e/features/epic-9-ui-redesign.feature
@@ -1,0 +1,66 @@
+Feature: UI Redesign and Theming
+  As a race engineer
+  I want a consistent WEC/LMU-inspired dark theme
+  So that the application looks professional and is comfortable to use during long race sessions
+
+  Background:
+    Given I am logged in as "engineer-theme@test.com"
+
+  Scenario: Dark theme is applied to body background
+    Given I am on the dashboard page
+    Then the body background colour should be dark
+    And the computed background of the body should be the base dark colour
+
+  Scenario: Dark theme is applied to the header
+    Given I am on the dashboard page
+    Then the header should have a dark surface background
+
+  Scenario: WEC red accent colour is used on primary buttons
+    Given I am on the dashboard page
+    Then primary buttons should use the WEC red accent colour
+
+  Scenario: CSS custom property design token system exists
+    Given I am on the dashboard page
+    Then the CSS custom property "--color-accent" should be defined
+    And the CSS custom property "--color-bg-base" should be defined
+    And the CSS custom property "--color-text-primary" should be defined
+
+  Scenario: Typography uses the Inter font family
+    Given I am on the dashboard page
+    Then the body font family should include "Inter"
+
+  Scenario: Theme is consistent on the Race Creation page
+    Given I navigate to the race creation page
+    Then the page card should have a dark surface background
+    And primary buttons should use the WEC red accent colour
+
+  Scenario: Theme is consistent on the Strategy Creation page
+    Given a race exists with name "Theme Test Race"
+    And I navigate to the strategy creation page for that race
+    Then the page card should have a dark surface background
+
+  Scenario: Status badge renders with active variant styling
+    Given a race exists with an active strategy
+    And I am on the dashboard page
+    Then the strategy badge with variant "active" should be visible
+    And the active badge should use the success colour
+
+  Scenario: Status badge renders with planned variant styling
+    Given a race exists without an active strategy
+    And I am on the dashboard page
+    Then the strategy badge with variant "planned" should be visible
+
+  Scenario: Driver timeline colours are distinct from WEC red
+    Given a race exists with a strategy that has stints
+    And I navigate to the race execution page for that race
+    Then the timeline blocks should not use the WEC red colour "#e8001d"
+
+  Scenario: Application is responsive at 1280px viewport width
+    Given I am on the dashboard page
+    When the viewport is set to 1280px wide
+    Then the page layout should be visible without horizontal scrolling
+
+  Scenario: No functional regression on login page
+    Given I am not logged in
+    Then the login page should render correctly
+    And the login form should have email and password inputs

--- a/e2e/steps/epic-9-ui-redesign.js
+++ b/e2e/steps/epic-9-ui-redesign.js
@@ -1,0 +1,263 @@
+const { Given, When, Then } = require('@cucumber/cucumber');
+const { expect } = require('@playwright/test');
+
+// ──────────────────────────────────────────────
+// Helper: create a race via API and store its id
+// ──────────────────────────────────────────────
+async function createRace(world, name, activateStrategy = false) {
+  const res = await fetch(`${world.apiUrl}/api/races`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: world.cookie },
+    body: JSON.stringify({
+      name,
+      track: 'Monza',
+      durationHours: 6,
+      drivers: [
+        { name: 'Driver A', avgLapTimeMs: 90000 },
+        { name: 'Driver B', avgLapTimeMs: 91000 },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to create race: ${await res.text()}`);
+  const race = await res.json();
+
+  if (activateStrategy) {
+    const calcRes = await fetch(`${world.apiUrl}/api/strategies/${race.id}/calculate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: world.cookie },
+      body: JSON.stringify({ name: 'Default', fuelPerLap: 3.5, energyPerLap: 2.0, estimatedTotalLaps: 240 }),
+    });
+    if (calcRes.ok) {
+      const variants = await calcRes.json();
+      const strategyId = Array.isArray(variants) ? variants[0].id : variants.id;
+      await fetch(`${world.apiUrl}/api/strategies/${race.id}/activate/${strategyId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: world.cookie },
+      });
+    }
+  }
+  return race;
+}
+
+// ──────────────────────────────────────────────
+// Navigation steps
+// ──────────────────────────────────────────────
+
+Given('I am on the dashboard page', async function () {
+  await this.page.goto(`${this.baseUrl}/`);
+  await this.page.waitForLoadState('networkidle');
+});
+
+Given('I navigate to the race creation page', async function () {
+  await this.page.goto(`${this.baseUrl}/races/new`);
+  await this.page.waitForLoadState('networkidle');
+});
+
+Given('a race exists with name {string}', async function (name) {
+  this.theRace = await createRace(this, name, false);
+});
+
+Given('I navigate to the strategy creation page for that race', async function () {
+  await this.page.goto(`${this.baseUrl}/races/${this.theRace.id}/strategy/new`);
+  await this.page.waitForLoadState('networkidle');
+});
+
+Given('a race exists with an active strategy', async function () {
+  this.theRace = await createRace(this, `Theme Active ${Date.now()}`, true);
+});
+
+Given('a race exists without an active strategy', async function () {
+  this.theRace = await createRace(this, `Theme Planned ${Date.now()}`, false);
+});
+
+Given('a race exists with a strategy that has stints', async function () {
+  this.theRace = await createRace(this, `Theme Stints ${Date.now()}`, true);
+});
+
+Given('I navigate to the race execution page for that race', async function () {
+  await this.page.goto(`${this.baseUrl}/races/${this.theRace.id}`);
+  await this.page.waitForLoadState('networkidle');
+});
+
+// ──────────────────────────────────────────────
+// Dark theme checks
+// ──────────────────────────────────────────────
+
+Then('the body background colour should be dark', async function () {
+  const bg = await this.page.evaluate(() => {
+    return window.getComputedStyle(document.body).backgroundColor;
+  });
+  // rgb(11, 15, 23) = #0b0f17 — the base dark colour
+  // Accept any very dark background (all channels below 30)
+  const match = bg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match.map(Number);
+  expect(r).toBeLessThan(40);
+  expect(g).toBeLessThan(40);
+  expect(b).toBeLessThan(60);
+});
+
+Then('the computed background of the body should be the base dark colour', async function () {
+  const bg = await this.page.evaluate(() => {
+    return window.getComputedStyle(document.body).backgroundColor;
+  });
+  // #0b0f17 = rgb(11, 15, 23)
+  expect(bg).toBe('rgb(11, 15, 23)');
+});
+
+Then('the header should have a dark surface background', async function () {
+  const bg = await this.page.evaluate(() => {
+    const header = document.querySelector('header');
+    if (!header) return null;
+    return window.getComputedStyle(header).backgroundColor;
+  });
+  expect(bg).not.toBeNull();
+  // #151c28 = rgb(21, 28, 40)
+  const match = bg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match.map(Number);
+  expect(r).toBeLessThan(50);
+  expect(g).toBeLessThan(50);
+  expect(b).toBeLessThan(70);
+});
+
+// ──────────────────────────────────────────────
+// WEC red accent on primary buttons
+// ──────────────────────────────────────────────
+
+Then('primary buttons should use the WEC red accent colour', async function () {
+  const bg = await this.page.evaluate(() => {
+    const btn = document.querySelector('.btn-primary');
+    if (!btn) return null;
+    return window.getComputedStyle(btn).backgroundColor;
+  });
+  expect(bg).not.toBeNull();
+  // --color-accent: #e8001d = rgb(232, 0, 29)
+  const match = bg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match.map(Number);
+  // Red channel should be high, green and blue should be very low
+  expect(r).toBeGreaterThan(200);
+  expect(g).toBeLessThan(20);
+  expect(b).toBeLessThan(50);
+});
+
+// ──────────────────────────────────────────────
+// CSS custom property token system
+// ──────────────────────────────────────────────
+
+Then('the CSS custom property {string} should be defined', async function (propertyName) {
+  const value = await this.page.evaluate((prop) => {
+    return getComputedStyle(document.documentElement).getPropertyValue(prop).trim();
+  }, propertyName);
+  expect(value).not.toBe('');
+});
+
+// ──────────────────────────────────────────────
+// Typography
+// ──────────────────────────────────────────────
+
+Then('the body font family should include {string}', async function (fontName) {
+  const fontFamily = await this.page.evaluate(() => {
+    return window.getComputedStyle(document.body).fontFamily;
+  });
+  expect(fontFamily.toLowerCase()).toContain(fontName.toLowerCase());
+});
+
+// ──────────────────────────────────────────────
+// Page card surface background
+// ──────────────────────────────────────────────
+
+Then('the page card should have a dark surface background', async function () {
+  const bg = await this.page.evaluate(() => {
+    const card = document.querySelector('.page-card');
+    if (!card) return null;
+    return window.getComputedStyle(card).backgroundColor;
+  });
+  expect(bg).not.toBeNull();
+  // #151c28 = rgb(21, 28, 40)
+  const match = bg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match.map(Number);
+  expect(r).toBeLessThan(50);
+  expect(g).toBeLessThan(50);
+  expect(b).toBeLessThan(70);
+});
+
+// ──────────────────────────────────────────────
+// Status badge variants
+// ──────────────────────────────────────────────
+
+Then('the strategy badge with variant {string} should be visible', async function (variant) {
+  await this.page.goto(`${this.baseUrl}/`);
+  await this.page.waitForLoadState('networkidle');
+  await expect(this.page.locator(`.badge-${variant}`).first()).toBeVisible({ timeout: 5000 });
+});
+
+Then('the active badge should use the success colour', async function () {
+  const color = await this.page.evaluate(() => {
+    const badge = document.querySelector('.badge-active');
+    if (!badge) return null;
+    return window.getComputedStyle(badge).color;
+  });
+  expect(color).not.toBeNull();
+  // --color-success: #22c55e = rgb(34, 197, 94)
+  const match = color.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match.map(Number);
+  // Green channel should dominate
+  expect(g).toBeGreaterThan(150);
+  expect(r).toBeLessThan(100);
+});
+
+// ──────────────────────────────────────────────
+// Driver timeline colours distinct from WEC red
+// ──────────────────────────────────────────────
+
+Then('the timeline blocks should not use the WEC red colour {string}', async function (wecRed) {
+  const timeline = this.page.locator('[data-testid="timeline"]');
+  const count = await this.page.locator('[data-testid^="timeline-block-"]').count();
+  if (count === 0) {
+    // No stints rendered yet — skip colour check
+    return;
+  }
+  const colors = await this.page.evaluate(() => {
+    const blocks = document.querySelectorAll('[data-testid^="timeline-block-"]');
+    return Array.from(blocks).map(b => window.getComputedStyle(b).backgroundColor);
+  });
+  // Convert #e8001d to rgb for comparison
+  for (const color of colors) {
+    expect(color).not.toBe('rgb(232, 0, 29)');
+  }
+});
+
+// ──────────────────────────────────────────────
+// Responsive layout at 1280px
+// ──────────────────────────────────────────────
+
+When('the viewport is set to 1280px wide', async function () {
+  await this.page.setViewportSize({ width: 1280, height: 800 });
+});
+
+Then('the page layout should be visible without horizontal scrolling', async function () {
+  const scrollWidth = await this.page.evaluate(() => document.documentElement.scrollWidth);
+  const clientWidth = await this.page.evaluate(() => document.documentElement.clientWidth);
+  expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1); // +1 for sub-pixel rounding
+});
+
+// ──────────────────────────────────────────────
+// Login page regression
+// ──────────────────────────────────────────────
+
+Then('the login page should render correctly', async function () {
+  // Clear session so the app does not redirect an authenticated user away from /login
+  await this.context.clearCookies();
+  await this.page.goto(`${this.baseUrl}/login`);
+  await this.page.waitForLoadState('networkidle');
+  await expect(this.page.locator('.login-card')).toBeVisible({ timeout: 5000 });
+});
+
+Then('the login form should have email and password inputs', async function () {
+  await expect(this.page.locator('input[type="email"]')).toBeVisible();
+  await expect(this.page.locator('input[type="password"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Replace all hardcoded hex colour values with CSS custom property tokens sourced from a new `tokens.css` file
- Apply a WEC/LMU-inspired dark palette: deep navy backgrounds, WEC red (`#e8001d`) as primary accent, blue (`#1e90ff`) as secondary accent, semantic success/warning/danger tokens
- Add reusable `PageCard` and `StatusBadge` components; update all pages to use them

## Changes
- `client/src/tokens.css` (new): CSS custom properties for the full design token set — surfaces, borders, text, accents, typography scale, spacing, radii, transitions
- `client/src/styles.css`: full rewrite replacing every hardcoded hex/px value with `var(--)` tokens; preserves all existing class names used by E2E tests; adds `.page-card`, `.badge-active`, `.badge-warning`, `.badge-planned` rules
- `client/src/main.jsx`: adds `import './tokens.css'` as first import
- `client/src/constants.js`: exports `DRIVER_COLORS` array (6 distinct driver colours, intentionally excluding WEC red)
- `client/src/components/PageCard.jsx` (new): thin wrapper component for page-level cards
- `client/src/components/StatusBadge.jsx` (new): badge component with variant-based class names
- `client/src/pages/RaceCreate.jsx`: uses `<PageCard>`
- `client/src/pages/StrategyCreate.jsx`: uses `<PageCard>`
- `client/src/pages/StrategyCompare.jsx`: uses `<PageCard>` and imports `StatusBadge`
- `client/src/pages/Dashboard.jsx`: uses `<StatusBadge>`
- `client/src/pages/RaceExecution.jsx`: imports `DRIVER_COLORS` from constants instead of inline array
- `client/index.html`: adds Google Fonts preconnect and Inter font stylesheet

## Testing
- Run `npm test` — unit tests (Pit Time Calculator, Strategy Engine) all pass
- Run `npm run test:e2e` — all class names and `data-testid` attributes are preserved, so existing E2E scenarios should continue to pass
- Start `npm run dev` and visually verify the dark theme, red primary buttons, blue header/links, and driver timeline colours

Closes #21